### PR TITLE
Increase Subaru RPM limit

### DIFF
--- a/board/safety/safety_subaru.h
+++ b/board/safety/safety_subaru.h
@@ -29,7 +29,7 @@ const LongitudinalLimits SUBARU_LONG_LIMITS = {
   .max_brake = 600,     // approx -3.5 m/s^2
 
   .min_transmission_rpm = 0,
-  .max_transmission_rpm = 2400,
+  .max_transmission_rpm = 3600,
 };
 
 #define MSG_SUBARU_Brake_Status          0x13c

--- a/tests/safety/test_subaru.py
+++ b/tests/safety/test_subaru.py
@@ -129,7 +129,7 @@ class TestSubaruLongitudinalSafetyBase(TestSubaruSafetyBase, common.Longitudinal
   MAX_POSSIBLE_BRAKE = 2**16
 
   MIN_RPM = 0
-  MAX_RPM = 2400
+  MAX_RPM = 3600
   MAX_POSSIBLE_RPM = 2**13
 
   FWD_BLACKLISTED_ADDRS = {2: [SubaruMsg.ES_LKAS, SubaruMsg.ES_Brake, SubaruMsg.ES_Distance,


### PR DESCRIPTION
**I am aware this may be a controversial PR, however I am willing to help in any way I can.**

The Subaru RPM limit is simply too low for some areas. Where I am (Western Mass) is *very* hilly, and OpenPilot/SunnyPilot cannot keep up with the other cars. This is also true on the highways, it rarely keeps up with the speeds that MA drivers are at (appox. 80 to 85mph).

Increasing the RPM limit will allow the car to keep up on hills and have a consistent speed on highways.

I'm aware that Panda safety modifications can result in a device ban from Comma Connect, though I'm hoping this won't be the case.