### PR TITLE
Allow cancel command with stock TACC

### DIFF
--- a/board/safety/safety_tesla.h
+++ b/board/safety/safety_tesla.h
@@ -132,6 +132,7 @@ static bool tesla_tx_hook(const CANPacket_t *to_send) {
 
   if(addr == 0x2b9) {
     // DAS_control: longitudinal control message
+    int acc_state = ((GET_BYTE(to_send, 1) & 0xF0U) >> 4);
     if (tesla_longitudinal) {
       // No AEB events may be sent by openpilot
       int aeb_event = GET_BYTE(to_send, 2) & 0x03U;
@@ -149,6 +150,14 @@ static bool tesla_tx_hook(const CANPacket_t *to_send) {
       int raw_accel_min = ((GET_BYTE(to_send, 5) & 0x0FU) << 5) | (GET_BYTE(to_send, 4) >> 3);
       violation |= longitudinal_accel_checks(raw_accel_max, TESLA_LONG_LIMITS);
       violation |= longitudinal_accel_checks(raw_accel_min, TESLA_LONG_LIMITS);
+    } else if(acc_state == 13) {
+      // Allow sending of acc_state 13 to cancel TACC by OP
+
+      // Don't send messages when the stock AEB system is active
+      if (tesla_stock_aeb) {
+        violation = true;
+      }
+
     } else {
       violation = true;
     }


### PR DESCRIPTION
This is a prereq to sending a direct ACC cancel command via das_control even when using stock TACC, eliminating the need to inject fake right-stalk presses to cancel (which causes annoying alerts due to race conditions with the real stalk signal)

This pass-through is necessary to allow sending only an ACC cancel command even when not normally passing long control messages.

**Safety considerations:**

- This ensures we do not send a conflicting message when Tesla's AEB is active
- When acc_state is set to 13, acceleration and speed values are ignored, as 13 is the acc_cancel value

**Route:**

`bbbf82d987d681bc/00000067--d2efd037e6/0` (Using stock TACC)

`bbbf82d987d681bc/00000068--e00c40131b/0` (Using OP long)