### PR TITLE
Tesla mads fixes

### DIFF
--- a/board/safety/safety_tesla.h
+++ b/board/safety/safety_tesla.h
@@ -34,7 +34,7 @@ RxCheck tesla_model3_y_rx_checks[] = {
   {.msg = {{0x286, 0, 8, .frequency = 10U}, { 0 }, { 0 }}},   // DI_state (acc state)
   {.msg = {{0x311, 0, 7, .frequency = 10U}, { 0 }, { 0 }}},   // UI_warning (buckle switch & doors)
   {.msg = {{0x3f5, 1, 8, .frequency = 10U}, { 0 }, { 0 }}},   // ID3F5VCFRONT_lighting (blinkers)
-  {.msg = {{0x229, 1, 3, .frequency = 10U}, { 0 }, { 0 }}},   // SCCM_rightStalk (right control lever)
+  {.msg = {{0x3c2, 1, 8, .frequency = 20U}, { 0 }, { 0 }}},   // VCLEFT_switchStatus
 };
 
 bool tesla_longitudinal = false;
@@ -82,10 +82,14 @@ static void tesla_rx_hook(const CANPacket_t *to_push) {
   }
 
   if (bus == 1) {
-    if (addr == 0x229) {
-      int sccm_right_stalk = (GET_BYTE(to_push, 1) >> 4) & 0x7U;
-      bool mads_enabled = sccm_right_stalk == 3;
-      mads_lkas_button_check(mads_enabled);
+    if (addr == 0x3c2) {
+      int mux = GET_BYTE(to_push, 0) & 0x03U;
+      if (mux == 1) {
+        // TODO: check for double-click only to match actual activation
+        int swc_right_pressed = ((GET_BYTE(to_push, 1) & 0x30U) >> 4);
+        bool mads_enabled = swc_right_pressed == 2;
+        mads_lkas_button_check(mads_enabled);
+      }
     }
   }
 

--- a/board/safety/safety_tesla.h
+++ b/board/safety/safety_tesla.h
@@ -35,6 +35,7 @@ RxCheck tesla_model3_y_rx_checks[] = {
   {.msg = {{0x311, 0, 7, .frequency = 10U}, { 0 }, { 0 }}},   // UI_warning (buckle switch & doors)
   {.msg = {{0x3f5, 1, 8, .frequency = 10U}, { 0 }, { 0 }}},   // ID3F5VCFRONT_lighting (blinkers)
   {.msg = {{0x3c2, 1, 8, .frequency = 20U}, { 0 }, { 0 }}},   // VCLEFT_switchStatus
+  {.msg = {{0x3df, 1, 6, .frequency = 2U}, { 0 }, { 0 }}},    // UI_status2 (Variable freq, min 2hz)
 };
 
 bool tesla_longitudinal = false;
@@ -82,14 +83,10 @@ static void tesla_rx_hook(const CANPacket_t *to_push) {
   }
 
   if (bus == 1) {
-    if (addr == 0x3c2) {
-      int mux = GET_BYTE(to_push, 0) & 0x03U;
-      if (mux == 1) {
-        // TODO: check for double-click only to match actual activation
-        int swc_right_pressed = ((GET_BYTE(to_push, 1) & 0x30U) >> 4);
-        bool mads_enabled = swc_right_pressed == 2;
-        mads_lkas_button_check(mads_enabled);
-      }
+    if (addr == 0x3df) {
+      int ui_active_touch_points = GET_BYTE(to_push, 3);
+      bool mads_enabled = ui_active_touch_points == 3U;
+      mads_lkas_button_check(mads_enabled);
     }
   }
 


### PR DESCRIPTION
Required for https://github.com/sunnypilot/sunnypilot/pull/392

This is a prereq to sending a direct ACC cancel command via das_control even when using stock TACC, eliminating the need to inject fake right-stalk presses to cancel (which causes annoying alerts due to race conditions with the real stalk signal)

This pass-through is necessary to allow sending only an ACC cancel command even when not normally passing long control messages.

Additionally this changes the MADS enablement to activeTouchPoints == 3 (3-finger tap), as overloading the stalk with acc and mads was too confusing and buggy.

**Safety considerations:**

- This ensures we do not send a conflicting message when Tesla's AEB is active
- When acc_state is set to 13, acceleration and speed values are ignored, as 13 is the acc_cancel value
