### PR TITLE
MADS: disable the exit controls if lagging temporarily 

### DIFF
--- a/board/safety.h
+++ b/board/safety.h
@@ -307,7 +307,8 @@ void safety_tick(const safety_config *cfg) {
       cfg->rx_checks[i].status.lagging = lagging;
       if (lagging) {
         controls_allowed = false;
-        mads_exit_controls();
+        // TODO-SP: this should be handled (likely https://github.com/sunnypilot/panda/pull/48), not simply ignoring it 
+        // mads_exit_controls();
       }
 
       if (lagging || !is_msg_valid(cfg->rx_checks, i)) {

--- a/tests/safety/common.py
+++ b/tests/safety/common.py
@@ -986,8 +986,10 @@ class PandaCarSafetyTest(PandaSafetyTest, MadsCommonBase):
   def test_safety_tick(self):
     self.safety.set_timer(int(2e6))
     self.safety.set_controls_allowed(True)
-    self.safety.set_controls_allowed_lat(True)
+    # TODO-SP: this should be handled (likely https://github.com/sunnypilot/panda/pull/48), not simply ignoring it
+    # self.safety.set_controls_allowed_lat(True)
     self.safety.safety_tick_current_safety_config()
     self.assertFalse(self.safety.get_controls_allowed())
-    self.assertFalse(self.safety.get_controls_allowed_lat())
+    # TODO-SP: this should be handled (likely https://github.com/sunnypilot/panda/pull/48), not simply ignoring it
+    # self.assertFalse(self.safety.get_controls_allowed_lat())
     self.assertFalse(self.safety.safety_config_valid())


### PR DESCRIPTION
to avoid errors while we finish https://github.com/sunnypilot/panda/pull/48