### PR TITLE
MADS: Chrysler: Allow `LKAS_HEARTBIT`

### DIFF
--- a/board/safety/safety_chrysler.h
+++ b/board/safety/safety_chrysler.h
@@ -11,6 +11,7 @@ typedef struct {
   const int DAS_6;
   const int LKAS_COMMAND;
   const int CRUISE_BUTTONS;
+  const int LKAS_HEARTBIT;
 } ChryslerAddrs;
 
 typedef enum {
@@ -176,7 +177,7 @@ static int chrysler_fwd_hook(int bus_num, int addr) {
   }
 
   // forward all messages from camera except LKAS messages
-  const bool is_lkas = ((addr == chrysler_addrs->LKAS_COMMAND) || (addr == chrysler_addrs->DAS_6));
+  const bool is_lkas = ((addr == chrysler_addrs->LKAS_COMMAND) || (addr == chrysler_addrs->DAS_6) || (addr == chrysler_addrs->LKAS_HEARTBIT));
   if ((bus_num == 2) && !is_lkas){
     bus_fwd = 0;
   }
@@ -198,6 +199,7 @@ static safety_config chrysler_init(uint16_t param) {
     .DAS_6            = 0x2A6,  // LKAS HUD and auto headlight control from DASM
     .LKAS_COMMAND     = 0x292,  // LKAS controls from DASM
     .CRUISE_BUTTONS   = 0x23B,  // Cruise control buttons
+    .LKAS_HEARTBIT    = 0x2D9,  // LKAS HEARTBIT from DASM
   };
 
   // CAN messages for the 5th gen RAM DT platform
@@ -233,6 +235,7 @@ static safety_config chrysler_init(uint16_t param) {
     {CHRYSLER_ADDRS.CRUISE_BUTTONS, 0, 3},
     {CHRYSLER_ADDRS.LKAS_COMMAND, 0, 6},
     {CHRYSLER_ADDRS.DAS_6, 0, 8},
+    {CHRYSLER_ADDRS.LKAS_HEARTBIT, 0, 5},
   };
 
   static const CanMsg CHRYSLER_RAM_DT_TX_MSGS[] = {

--- a/board/safety/safety_chrysler.h
+++ b/board/safety/safety_chrysler.h
@@ -177,7 +177,8 @@ static int chrysler_fwd_hook(int bus_num, int addr) {
   }
 
   // forward all messages from camera except LKAS messages
-  const bool is_lkas = ((addr == chrysler_addrs->LKAS_COMMAND) || (addr == chrysler_addrs->DAS_6) || (addr == chrysler_addrs->LKAS_HEARTBIT));
+  const bool is_lkas_heartbit = (addr == chrysler_addrs->LKAS_HEARTBIT) && (chrysler_platform == CHRYSLER_PACIFICA);
+  const bool is_lkas = ((addr == chrysler_addrs->LKAS_COMMAND) || (addr == chrysler_addrs->DAS_6) || is_lkas_heartbit);
   if ((bus_num == 2) && !is_lkas){
     bus_fwd = 0;
   }

--- a/tests/safety/test_chrysler.py
+++ b/tests/safety/test_chrysler.py
@@ -7,10 +7,10 @@ from panda.tests.safety.common import CANPackerPanda
 
 
 class TestChryslerSafety(common.PandaCarSafetyTest, common.MotorTorqueSteeringSafetyTest):
-  TX_MSGS = [[0x23B, 0], [0x292, 0], [0x2A6, 0]]
+  TX_MSGS = [[0x23B, 0], [0x292, 0], [0x2A6, 0], [0x2D9, 0]]
   STANDSTILL_THRESHOLD = 0
   RELAY_MALFUNCTION_ADDRS = {0: (0x292,)}
-  FWD_BLACKLISTED_ADDRS = {2: [0x292, 0x2A6]}
+  FWD_BLACKLISTED_ADDRS = {2: [0x292, 0x2A6, 0x2D9]}
   FWD_BUS_LOOKUP = {0: 2, 2: 0}
 
   MAX_RATE_UP = 3


### PR DESCRIPTION
Failed `test_models` with Chrysler tx of `LKAS_HEARTBIT`: https://github.com/sunnypilot/sunnypilot/actions/runs/12207449242/job/34058907384