### PR TITLE
MADS: Honda: Allow steering

### DIFF
--- a/board/safety/safety_honda.h
+++ b/board/safety/safety_honda.h
@@ -276,7 +276,7 @@ static bool honda_tx_hook(const CANPacket_t *to_send) {
 
   // STEER: safety check
   if ((addr == 0xE4) || (addr == 0x194)) {
-    if (!controls_allowed) {
+    if (!(controls_allowed || mads_is_lateral_control_allowed_by_mads())) {
       bool steer_applied = GET_BYTE(to_send, 0) | GET_BYTE(to_send, 1);
       if (steer_applied) {
         tx = false;


### PR DESCRIPTION
## Summary by Sourcery

New Features:
- Enable steering when MADS lateral control is allowed.