### PR TITLE
Sync: `commaai/panda:master` into `sunnypilot/panda:master-new`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ RUN pip3 install --break-system-packages --no-cache-dir $PYTHONPATH/panda/[dev]
 
 # TODO: this should be a "pip install" or not even in this repo at all
 RUN git config --global --add safe.directory $PYTHONPATH/panda
-ENV OPENDBC_REF="17530f1ae692b26353a48daf075ad79bbffdb189"
+ENV OPENDBC_REF="a280fed7a3d250be3a96e626b81b13d8223b704d"
 RUN cd /tmp/ && \
     git clone --depth 1 https://github.com/sunnypilot/opendbc opendbc_repo && \
     cd opendbc_repo && git fetch origin $OPENDBC_REF && git checkout FETCH_HEAD && rm -rf .git/ && \

--- a/board/safety/safety_ford.h
+++ b/board/safety/safety_ford.h
@@ -368,42 +368,33 @@ static safety_config ford_init(uint16_t param) {
     {.msg = {{FORD_DesiredTorqBrk, 0, 8, .frequency = 50U}, { 0 }, { 0 }}},
   };
 
+  #define FORD_COMMON_TX_MSGS       \
+    {FORD_Steering_Data_FD1, 0, 8}, \
+    {FORD_Steering_Data_FD1, 2, 8}, \
+    {FORD_ACCDATA_3, 0, 8},         \
+    {FORD_Lane_Assist_Data1, 0, 8}, \
+    {FORD_IPMA_Data, 0, 8},         \
+
   static const CanMsg FORD_CANFD_LONG_TX_MSGS[] = {
-    {FORD_Steering_Data_FD1, 0, 8},
-    {FORD_Steering_Data_FD1, 2, 8},
+    FORD_COMMON_TX_MSGS
     {FORD_ACCDATA, 0, 8},
-    {FORD_ACCDATA_3, 0, 8},
-    {FORD_Lane_Assist_Data1, 0, 8},
     {FORD_LateralMotionControl2, 0, 8},
-    {FORD_IPMA_Data, 0, 8},
   };
 
   static const CanMsg FORD_CANFD_STOCK_TX_MSGS[] = {
-    {FORD_Steering_Data_FD1, 0, 8},
-    {FORD_Steering_Data_FD1, 2, 8},
-    {FORD_ACCDATA_3, 0, 8},
-    {FORD_Lane_Assist_Data1, 0, 8},
+    FORD_COMMON_TX_MSGS
     {FORD_LateralMotionControl2, 0, 8},
-    {FORD_IPMA_Data, 0, 8},
   };
 
   static const CanMsg FORD_STOCK_TX_MSGS[] = {
-    {FORD_Steering_Data_FD1, 0, 8},
-    {FORD_Steering_Data_FD1, 2, 8},
-    {FORD_ACCDATA_3, 0, 8},
-    {FORD_Lane_Assist_Data1, 0, 8},
+    FORD_COMMON_TX_MSGS
     {FORD_LateralMotionControl, 0, 8},
-    {FORD_IPMA_Data, 0, 8},
   };
 
   static const CanMsg FORD_LONG_TX_MSGS[] = {
-    {FORD_Steering_Data_FD1, 0, 8},
-    {FORD_Steering_Data_FD1, 2, 8},
+    FORD_COMMON_TX_MSGS
     {FORD_ACCDATA, 0, 8},
-    {FORD_ACCDATA_3, 0, 8},
-    {FORD_Lane_Assist_Data1, 0, 8},
     {FORD_LateralMotionControl, 0, 8},
-    {FORD_IPMA_Data, 0, 8},
   };
 
   UNUSED(param);
@@ -414,6 +405,9 @@ static safety_config ford_init(uint16_t param) {
   ford_canfd = GET_FLAG(param, FORD_PARAM_CANFD);
 #endif
 
+  // Longitudinal is the default for CAN, and optional for CAN FD w/ ALLOW_DEBUG
+  ford_longitudinal = !ford_canfd || ford_longitudinal;
+
   safety_config ret;
   // FIXME: cppcheck thinks that ford_canfd is always false. This is not true
   // if ALLOW_DEBUG is defined but cppcheck is run without ALLOW_DEBUG
@@ -422,6 +416,7 @@ static safety_config ford_init(uint16_t param) {
     ret = ford_longitudinal ? BUILD_SAFETY_CFG(ford_rx_checks, FORD_CANFD_LONG_TX_MSGS) : \
                               BUILD_SAFETY_CFG(ford_rx_checks, FORD_CANFD_STOCK_TX_MSGS);
   } else {
+    // cppcheck-suppress knownConditionTrueFalse
     ret = ford_longitudinal ? BUILD_SAFETY_CFG(ford_rx_checks, FORD_LONG_TX_MSGS) : \
                               BUILD_SAFETY_CFG(ford_rx_checks, FORD_STOCK_TX_MSGS);
   }

--- a/board/stm32h7/lladc.h
+++ b/board/stm32h7/lladc.h
@@ -19,9 +19,9 @@ static uint16_t adc_get_raw(uint8_t channel) {
   ADC1->SQR1 &= ~(ADC_SQR1_L);
   ADC1->SQR1 = (uint32_t)channel << 6U;
 
-  ADC1->SMPR1 = 0x2UL << (channel * 3UL);
+  ADC1->SMPR1 = 0x4UL << (channel * 3UL);
   ADC1->PCSEL_RES0 = (0x1UL << channel);
-  ADC1->CFGR2 = (127UL << ADC_CFGR2_OVSR_Pos) | (0x7U << ADC_CFGR2_OVSS_Pos) | ADC_CFGR2_ROVSE;
+  ADC1->CFGR2 = (63UL << ADC_CFGR2_OVSR_Pos) | (0x6U << ADC_CFGR2_OVSS_Pos) | ADC_CFGR2_ROVSE;
 
   ADC1->CR |= ADC_CR_ADSTART;
   while (!(ADC1->ISR & ADC_ISR_EOC));

--- a/examples/query_fw_versions.py
+++ b/examples/query_fw_versions.py
@@ -97,7 +97,7 @@ if __name__ == "__main__":
         resp = {}
         for uds_data_id in sorted(uds_data_ids):
           try:
-            data = uds_client.read_data_by_identifier(uds_data_id)
+            data = uds_client.read_data_by_identifier(DATA_IDENTIFIER_TYPE(uds_data_id))
             if data:
               resp[uds_data_id] = data
           except (NegativeResponseError, MessageTimeoutError, InvalidSubAddressError):

--- a/tests/safety/test_ford.py
+++ b/tests/safety/test_ford.py
@@ -60,7 +60,6 @@ class Buttons:
 
 
 # Ford safety has four different configurations tested here:
-#  * CAN with stock longitudinal
 #  * CAN with openpilot longitudinal
 #  * CAN FD with stock longitudinal
 #  * CAN FD with openpilot longitudinal
@@ -368,21 +367,6 @@ class TestFordSafetyBase(common.PandaCarSafetyTest):
       self._mads_states_cleanup()
 
 
-class TestFordStockSafety(TestFordSafetyBase):
-  STEER_MESSAGE = MSG_LateralMotionControl
-
-  TX_MSGS = [
-    [MSG_Steering_Data_FD1, 0], [MSG_Steering_Data_FD1, 2], [MSG_ACCDATA_3, 0], [MSG_Lane_Assist_Data1, 0],
-    [MSG_LateralMotionControl, 0], [MSG_IPMA_Data, 0],
-  ]
-
-  def setUp(self):
-    self.packer = CANPackerPanda("ford_lincoln_base_pt")
-    self.safety = libpanda_py.libpanda
-    self.safety.set_safety_hooks(Panda.SAFETY_FORD, 0)
-    self.safety.init_tests()
-
-
 class TestFordCANFDStockSafety(TestFordSafetyBase):
   STEER_MESSAGE = MSG_LateralMotionControl2
 
@@ -470,7 +454,8 @@ class TestFordLongitudinalSafety(TestFordLongitudinalSafetyBase):
   def setUp(self):
     self.packer = CANPackerPanda("ford_lincoln_base_pt")
     self.safety = libpanda_py.libpanda
-    self.safety.set_safety_hooks(Panda.SAFETY_FORD, Panda.FLAG_FORD_LONG_CONTROL)
+    # Make sure we enforce long safety even without long flag for CAN
+    self.safety.set_safety_hooks(Panda.SAFETY_FORD, 0)
     self.safety.init_tests()
 
 

--- a/tests/safety/test_toyota.py
+++ b/tests/safety/test_toyota.py
@@ -332,7 +332,7 @@ class TestToyotaSecOcSafety(TestToyotaStockLongitudinalBase):
   FWD_BLACKLISTED_ADDRS = {2: [0x2E4, 0x412, 0x191, 0x131]}
 
   def setUp(self):
-    self.packer = CANPackerPanda("toyota_rav4_prime_generated")
+    self.packer = CANPackerPanda("toyota_secoc_pt_generated")
     self.safety = libpanda_py.libpanda
     self.safety.set_safety_hooks(Panda.SAFETY_TOYOTA, self.EPS_SCALE | Panda.FLAG_TOYOTA_STOCK_LONGITUDINAL | Panda.FLAG_TOYOTA_SECOC)
     self.safety.init_tests()


### PR DESCRIPTION
## Summary by Sourcery

Update the Ford safety code to consolidate common transmit messages, set longitudinal control as the default for CAN, and make it optional for CAN FD with ALLOW_DEBUG. Update the ADC sampling configuration and the OpenDBC reference.  Update the UDS client to read data by identifier type. Update the Toyota safety test to use the "toyota_secoc_pt_generated" CAN packer.

Build:
- Update OpenDBC to 2faa7fb9b0de72c2e955b8d6991a46cf05c58dc9.

Tests:
- Update the Toyota SECOC safety test to use the correct CAN packer.