### PR TITLE
Sync: `commaai/panda:master` into `sunnypilot/panda:master-new`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,11 +37,11 @@ RUN pip3 install --break-system-packages --no-cache-dir $PYTHONPATH/panda/[dev]
 
 # TODO: this should be a "pip install" or not even in this repo at all
 RUN git config --global --add safe.directory $PYTHONPATH/panda
-ENV OPENDBC_REF="a280fed7a3d250be3a96e626b81b13d8223b704d"
+ENV OPENDBC_REF="bdccfc5fecf96bfade8d280b4d2422af0ef584ea"
 RUN cd /tmp/ && \
     git clone --depth 1 https://github.com/sunnypilot/opendbc opendbc_repo && \
     cd opendbc_repo && git fetch origin $OPENDBC_REF && git checkout FETCH_HEAD && rm -rf .git/ && \
-    pip3 install --break-system-packages --no-cache-dir Cython numpy  && \
+    pip3 install --break-system-packages --no-cache-dir Cython numpy pycapnp  && \
     ln -s $PWD/opendbc $PYTHONPATH/opendbc && \
     scons -j8 --minimal opendbc/
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,8 @@ For example, to receive CAN messages:
 ```
 And to send one on bus 0:
 ``` python
->>> panda.set_safety_mode(Panda.SAFETY_ALLOUTPUT)
+>>> from opendbc.safety import Safety
+>>> panda.set_safety_mode(Safety.SAFETY_ALLOUTPUT)
 >>> panda.can_send(0x1aa, b'message', 0)
 ```
 Note that you may have to setup [udev rules](https://github.com/commaai/panda/tree/master/drivers/linux) for Linux, such as
@@ -90,7 +91,7 @@ EOF
 sudo udevadm control --reload-rules && sudo udevadm trigger
 ```
 
-The panda jungle uses different udev rules. See [the repo](https://github.com/commaai/panda_jungle#udev-rules) for instructions. 
+The panda jungle uses different udev rules. See [the repo](https://github.com/commaai/panda_jungle#udev-rules) for instructions.
 
 ## Software interface support
 

--- a/__init__.py
+++ b/__init__.py
@@ -5,7 +5,7 @@ from .python.canhandle import CanHandle # noqa: F401
 from .python.utils import logger # noqa: F401
 from .python import (Panda, PandaDFU, isotp, # noqa: F401
                      pack_can_buffer, unpack_can_buffer, calculate_checksum,
-                     DLC_TO_LEN, LEN_TO_DLC, ALTERNATIVE_EXPERIENCE, CANPACKET_HEAD_SIZE)
+                     DLC_TO_LEN, LEN_TO_DLC, CANPACKET_HEAD_SIZE)
 
 
 # panda jungle

--- a/board/boards/cuatro.h
+++ b/board/boards/cuatro.h
@@ -9,13 +9,13 @@
 static void cuatro_set_led(uint8_t color, bool enabled) {
   switch (color) {
     case LED_RED:
-      set_gpio_output(GPIOD, 15, !enabled);
+      set_gpio_output(GPIOC, 6, !enabled);
       break;
     case LED_GREEN:
-      set_gpio_output(GPIOB, 2, !enabled);
+      set_gpio_output(GPIOC, 7, !enabled);
       break;
     case LED_BLUE:
-      set_gpio_output(GPIOE, 2, !enabled);
+      set_gpio_output(GPIOC, 9, !enabled);
       break;
     default:
       break;
@@ -79,9 +79,9 @@ static void cuatro_init(void) {
   red_chiplet_init();
 
   // init LEDs as open drain
-  set_gpio_output_type(GPIOE, 2, OUTPUT_TYPE_OPEN_DRAIN);
-  set_gpio_output_type(GPIOB, 2, OUTPUT_TYPE_OPEN_DRAIN);
-  set_gpio_output_type(GPIOD, 15, OUTPUT_TYPE_OPEN_DRAIN);
+  set_gpio_output_type(GPIOC, 6, OUTPUT_TYPE_OPEN_DRAIN);
+  set_gpio_output_type(GPIOC, 7, OUTPUT_TYPE_OPEN_DRAIN);
+  set_gpio_output_type(GPIOC, 9, OUTPUT_TYPE_OPEN_DRAIN);
 
   // more open drain
   set_gpio_output_type(GPIOD, 3, OUTPUT_TYPE_OPEN_DRAIN); // FAN_EN
@@ -135,8 +135,8 @@ static void cuatro_init(void) {
   set_gpio_alternate(GPIOC, 0, GPIO_AF8_SAI4);    // SAI4_FS_B
   set_gpio_alternate(GPIOD, 11, GPIO_AF10_SAI4);  // SAI4_SD_A
   set_gpio_alternate(GPIOE, 3, GPIO_AF8_SAI4);    // SAI4_SD_B
-  set_gpio_alternate(GPIOE, 4, GPIO_AF2_SAI1);    // SAI1_D2
-  set_gpio_alternate(GPIOE, 5, GPIO_AF2_SAI1);    // SAI1_CK2
+  set_gpio_alternate(GPIOE, 4, GPIO_AF3_DFSDM1);  // DFSDM1_DATIN3
+  set_gpio_alternate(GPIOE, 9, GPIO_AF3_DFSDM1);  // DFSDM1_CKOUT
   set_gpio_alternate(GPIOE, 6, GPIO_AF10_SAI4);   // SAI4_MCLK_B
   sound_init();
 }

--- a/board/drivers/fdcan.h
+++ b/board/drivers/fdcan.h
@@ -19,9 +19,16 @@ static bool can_set_speed(uint8_t can_number) {
 }
 
 void can_clear_send(FDCAN_GlobalTypeDef *FDCANx, uint8_t can_number) {
-  can_health[can_number].can_core_reset_cnt += 1U;
-  can_health[can_number].total_tx_lost_cnt += (FDCAN_TX_FIFO_EL_CNT - (FDCANx->TXFQS & FDCAN_TXFQS_TFFL)); // TX FIFO msgs will be lost after reset
-  llcan_clear_send(FDCANx);
+  static uint32_t last_reset = 0U;
+  uint32_t time = microsecond_timer_get();
+
+  // Resetting CAN core is a slow blocking operation, limit frequency
+  if (get_ts_elapsed(time, last_reset) > 100000U) {  // 10 Hz
+    can_health[can_number].can_core_reset_cnt += 1U;
+    can_health[can_number].total_tx_lost_cnt += (FDCAN_TX_FIFO_EL_CNT - (FDCANx->TXFQS & FDCAN_TXFQS_TFFL)); // TX FIFO msgs will be lost after reset
+    llcan_clear_send(FDCANx);
+    last_reset = time;
+  }
 }
 
 void update_can_health_pkt(uint8_t can_number, uint32_t ir_reg) {

--- a/board/jungle/boards/board_declarations.h
+++ b/board/jungle/boards/board_declarations.h
@@ -9,7 +9,7 @@ typedef void (*board_set_ignition)(bool enabled);
 typedef void (*board_set_individual_ignition)(uint8_t bitmask);
 typedef void (*board_set_harness_orientation)(uint8_t orientation);
 typedef void (*board_set_can_mode)(uint8_t mode);
-typedef void (*board_enable_can_transciever)(uint8_t transciever, bool enabled);
+typedef void (*board_enable_can_transceiver)(uint8_t transceiver, bool enabled);
 typedef void (*board_enable_header_pin)(uint8_t pin_num, bool enabled);
 typedef float (*board_get_channel_power)(uint8_t channel);
 typedef uint16_t (*board_get_sbu_mV)(uint8_t channel, uint8_t sbu);
@@ -28,7 +28,7 @@ struct board {
   board_set_individual_ignition set_individual_ignition;
   board_set_harness_orientation set_harness_orientation;
   board_set_can_mode set_can_mode;
-  board_enable_can_transciever enable_can_transciever;
+  board_enable_can_transceiver enable_can_transceiver;
   board_enable_header_pin enable_header_pin;
   board_get_channel_power get_channel_power;
   board_get_sbu_mV get_sbu_mV;

--- a/board/jungle/boards/board_v1.h
+++ b/board/jungle/boards/board_v1.h
@@ -18,8 +18,8 @@ void board_v1_set_led(uint8_t color, bool enabled) {
   }
 }
 
-void board_v1_enable_can_transciever(uint8_t transciever, bool enabled) {
-  switch (transciever) {
+void board_v1_enable_can_transceiver(uint8_t transceiver, bool enabled) {
+  switch (transceiver) {
     case 1U:
       set_gpio_output(GPIOC, 1, !enabled);
       break;
@@ -33,14 +33,14 @@ void board_v1_enable_can_transciever(uint8_t transciever, bool enabled) {
       set_gpio_output(GPIOB, 10, !enabled);
       break;
     default:
-      print("Invalid CAN transciever ("); puth(transciever); print("): enabling failed\n");
+      print("Invalid CAN transceiver ("); puth(transceiver); print("): enabling failed\n");
       break;
   }
 }
 
 void board_v1_set_can_mode(uint8_t mode) {
-  board_v1_enable_can_transciever(2U, false);
-  board_v1_enable_can_transciever(4U, false);
+  board_v1_enable_can_transceiver(2U, false);
+  board_v1_enable_can_transceiver(4U, false);
   switch (mode) {
     case CAN_MODE_NORMAL:
       print("Setting normal CAN mode\n");
@@ -52,7 +52,7 @@ void board_v1_set_can_mode(uint8_t mode) {
       set_gpio_alternate(GPIOB, 5, GPIO_AF9_CAN2);
       set_gpio_alternate(GPIOB, 6, GPIO_AF9_CAN2);
       can_mode = CAN_MODE_NORMAL;
-      board_v1_enable_can_transciever(2U, true);
+      board_v1_enable_can_transceiver(2U, true);
       break;
     case CAN_MODE_OBD_CAN2:
       print("Setting OBD CAN mode\n");
@@ -64,7 +64,7 @@ void board_v1_set_can_mode(uint8_t mode) {
       set_gpio_alternate(GPIOB, 12, GPIO_AF9_CAN2);
       set_gpio_alternate(GPIOB, 13, GPIO_AF9_CAN2);
       can_mode = CAN_MODE_OBD_CAN2;
-      board_v1_enable_can_transciever(4U, true);
+      board_v1_enable_can_transceiver(4U, true);
       break;
     default:
       print("Tried to set unsupported CAN mode: "); puth(mode); print("\n");
@@ -135,9 +135,9 @@ void board_v1_init(void) {
 
   board_v1_set_can_mode(CAN_MODE_NORMAL);
 
-  // Enable CAN transcievers
+  // Enable CAN transceivers
   for(uint8_t i = 1; i <= 4; i++) {
-    board_v1_enable_can_transciever(i, true);
+    board_v1_enable_can_transceiver(i, true);
   }
 
   // Disable LEDs
@@ -171,7 +171,7 @@ board board_v1 = {
   .set_individual_ignition = &unused_set_individual_ignition,
   .set_harness_orientation = &board_v1_set_harness_orientation,
   .set_can_mode = &board_v1_set_can_mode,
-  .enable_can_transciever = &board_v1_enable_can_transciever,
+  .enable_can_transceiver = &board_v1_enable_can_transceiver,
   .enable_header_pin = &unused_board_enable_header_pin,
   .get_channel_power = &board_v1_get_channel_power,
   .get_sbu_mV = &board_v1_get_sbu_mV,

--- a/board/jungle/boards/board_v2.h
+++ b/board/jungle/boards/board_v2.h
@@ -110,8 +110,8 @@ void board_v2_set_harness_orientation(uint8_t orientation) {
   }
 }
 
-void board_v2_enable_can_transciever(uint8_t transciever, bool enabled) {
-  switch (transciever) {
+void board_v2_enable_can_transceiver(uint8_t transceiver, bool enabled) {
+  switch (transceiver) {
     case 1U:
       set_gpio_output(GPIOG, 11, !enabled);
       break;
@@ -125,7 +125,7 @@ void board_v2_enable_can_transciever(uint8_t transciever, bool enabled) {
       set_gpio_output(GPIOB, 4, !enabled);
       break;
     default:
-      print("Invalid CAN transciever ("); puth(transciever); print("): enabling failed\n");
+      print("Invalid CAN transceiver ("); puth(transceiver); print("): enabling failed\n");
       break;
   }
 }
@@ -139,8 +139,8 @@ void board_v2_enable_header_pin(uint8_t pin_num, bool enabled) {
 }
 
 void board_v2_set_can_mode(uint8_t mode) {
-  board_v2_enable_can_transciever(2U, false);
-  board_v2_enable_can_transciever(4U, false);
+  board_v2_enable_can_transceiver(2U, false);
+  board_v2_enable_can_transceiver(4U, false);
   switch (mode) {
     case CAN_MODE_NORMAL:
       // B12,B13: disable normal mode
@@ -157,7 +157,7 @@ void board_v2_set_can_mode(uint8_t mode) {
       set_gpio_pullup(GPIOB, 6, PULL_NONE);
       set_gpio_alternate(GPIOB, 6, GPIO_AF9_FDCAN2);
       can_mode = CAN_MODE_NORMAL;
-      board_v2_enable_can_transciever(2U, true);
+      board_v2_enable_can_transceiver(2U, true);
       break;
     case CAN_MODE_OBD_CAN2:
       // B5,B6: disable normal mode
@@ -173,7 +173,7 @@ void board_v2_set_can_mode(uint8_t mode) {
       set_gpio_pullup(GPIOB, 13, PULL_NONE);
       set_gpio_alternate(GPIOB, 13, GPIO_AF9_FDCAN2);
       can_mode = CAN_MODE_OBD_CAN2;
-      board_v2_enable_can_transciever(4U, true);
+      board_v2_enable_can_transceiver(4U, true);
       break;
     default:
       break;
@@ -260,9 +260,9 @@ void board_v2_init(void) {
   // Normal CAN mode
   board_v2_set_can_mode(CAN_MODE_NORMAL);
 
-  // Enable CAN transcievers
+  // Enable CAN transceivers
   for(uint8_t i = 1; i <= 4; i++) {
-    board_v2_enable_can_transciever(i, true);
+    board_v2_enable_can_transceiver(i, true);
   }
 
   // Set to no harness orientation
@@ -321,7 +321,7 @@ board board_v2 = {
   .set_individual_ignition = &board_v2_set_individual_ignition,
   .set_harness_orientation = &board_v2_set_harness_orientation,
   .set_can_mode = &board_v2_set_can_mode,
-  .enable_can_transciever = &board_v2_enable_can_transciever,
+  .enable_can_transceiver = &board_v2_enable_can_transceiver,
   .enable_header_pin = &board_v2_enable_header_pin,
   .get_channel_power = &board_v2_get_channel_power,
   .get_sbu_mV = &board_v2_get_sbu_mV,

--- a/board/jungle/main_comms.h
+++ b/board/jungle/main_comms.h
@@ -226,7 +226,7 @@ int comms_control_handler(ControlPacket_t *req, uint8_t *resp) {
       break;
     // **** 0xf4: Set CAN transceiver enable pin
     case 0xf4:
-      current_board->enable_can_transciever(req->param1, req->param2 > 0U);
+      current_board->enable_can_transceiver(req->param1, req->param2 > 0U);
       break;
     // **** 0xf5: Set CAN silent mode
     case 0xf5:

--- a/board/jungle/scripts/loopback_test.py
+++ b/board/jungle/scripts/loopback_test.py
@@ -5,6 +5,7 @@ import contextlib
 import random
 from termcolor import cprint
 
+from opendbc.safety import Safety
 from panda import Panda, PandaJungle
 
 NUM_PANDAS_PER_TEST = 1
@@ -88,7 +89,7 @@ def can_loopback(sender):
 def test_loopback():
   # disable safety modes
   for panda in pandas:
-    panda.set_safety_mode(Panda.SAFETY_ELM327 if FOR_RELEASE_BUILDS else Panda.SAFETY_ALLOUTPUT)
+    panda.set_safety_mode(Safety.SAFETY_ELM327 if FOR_RELEASE_BUILDS else Safety.SAFETY_ALLOUTPUT)
 
   # perform loopback with jungle as a sender
   can_loopback(jungle)
@@ -99,7 +100,7 @@ def test_loopback():
 
   # enable safety modes
   for panda in pandas:
-    panda.set_safety_mode(Panda.SAFETY_SILENT)
+    panda.set_safety_mode(Safety.SAFETY_SILENT)
 
 #################################################################
 ############################# MAIN ##############################

--- a/board/jungle/scripts/spam_can.py
+++ b/board/jungle/scripts/spam_can.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import os
 import random
+from opendbc.safety import Safety
 from panda import PandaJungle
 
 def get_test_string():
@@ -9,7 +10,7 @@ def get_test_string():
 if __name__ == "__main__":
   p = PandaJungle()
 
-  p.set_safety_mode(PandaJungle.SAFETY_ALLOUTPUT)
+  p.set_safety_mode(Safety.SAFETY_ALLOUTPUT)
 
   print("Spamming all buses...")
   while True:

--- a/board/stm32h7/clock.h
+++ b/board/stm32h7/clock.h
@@ -109,6 +109,8 @@ void clock_init(void) {
   register_set(&(RCC->D2CCIP2R), RCC_D2CCIP2R_USBSEL_1 | RCC_D2CCIP2R_USBSEL_0, RCC_D2CCIP2R_USBSEL);
   // Configure clock source for FDCAN (PLL1Q at 80Mhz)
   register_set(&(RCC->D2CCIP1R), RCC_D2CCIP1R_FDCANSEL_0, RCC_D2CCIP1R_FDCANSEL);
+  // Configure clock source for DFSDM1
+  register_set_bits(&(RCC->D2CCIP1R), RCC_D2CCIP1R_DFSDM1SEL);
   // Configure clock source for ADC1,2,3 (per_ck(currently HSE))
   register_set(&(RCC->D3CCIPR), RCC_D3CCIPR_ADCSEL_1, RCC_D3CCIPR_ADCSEL);
   //Enable the Clock Security System

--- a/board/stm32h7/peripherals.h
+++ b/board/stm32h7/peripherals.h
@@ -124,6 +124,7 @@ void peripherals_init(void) {
   RCC->APB1LENR |= RCC_APB1LENR_DAC12EN; // DAC
 
   // Audio
+  RCC->APB2ENR |= RCC_APB2ENR_DFSDM1EN; // D/S demodulator for mic
   RCC->APB4ENR |= RCC_APB4ENR_SAI4EN;  // SAI4
 
   // Timers

--- a/examples/query_fw_versions.py
+++ b/examples/query_fw_versions.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python3
 import argparse
 from tqdm import tqdm
-from panda import Panda
+from opendbc.car.carlog import carlog
 from opendbc.car.uds import UdsClient, MessageTimeoutError, NegativeResponseError, InvalidSubAddressError, \
                             SESSION_TYPE, DATA_IDENTIFIER_TYPE
+from opendbc.safety import Safety
+from panda import Panda
 
 if __name__ == "__main__":
   parser = argparse.ArgumentParser()
@@ -17,6 +19,9 @@ if __name__ == "__main__":
   parser.add_argument("--bus")
   parser.add_argument('-s', '--serial', help="Serial number of panda to use")
   args = parser.parse_args()
+
+  if args.debug:
+    carlog.setLevel('DEBUG')
 
   if args.addr:
     addrs = [int(args.addr, base=16)]
@@ -59,7 +64,7 @@ if __name__ == "__main__":
     exit()
 
   panda = Panda(serial=args.serial)
-  panda.set_safety_mode(Panda.SAFETY_ELM327, 1 if args.no_obd else 0)
+  panda.set_safety_mode(Safety.SAFETY_ELM327, 1 if args.no_obd else 0)
   print("querying addresses ...")
   with tqdm(addrs) as t:
     for addr in t:
@@ -77,7 +82,7 @@ if __name__ == "__main__":
       for sub_addr in sub_addrs:
         sub_addr_str = hex(sub_addr) if sub_addr is not None else None
         t.set_description(f"{hex(addr)}, {sub_addr_str}")
-        uds_client = UdsClient(panda, addr, rx_addr, bus, sub_addr=sub_addr, timeout=0.2, debug=args.debug)
+        uds_client = UdsClient(panda, addr, rx_addr, bus, sub_addr=sub_addr, timeout=0.2)
         # Check for anything alive at this address, and switch to the highest
         # available diagnostic session without security access
         try:

--- a/examples/query_vin_and_stats.py
+++ b/examples/query_vin_and_stats.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import time
 import struct
+from opendbc.safety import Safety
 from panda import Panda
 from hexdump import hexdump
 from panda.python.isotp import isotp_send, isotp_recv
@@ -30,7 +31,7 @@ def get_supported_pids():
 
 if __name__ == "__main__":
   panda = Panda()
-  panda.set_safety_mode(Panda.SAFETY_ELM327)
+  panda.set_safety_mode(Safety.SAFETY_ELM327)
   panda.can_clear(0)
 
   # 09 02 = Get VIN

--- a/examples/tesla_tester.py
+++ b/examples/tesla_tester.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import binascii
+from opendbc.safety import Safety
 from panda import Panda
 
 def tesla_tester():
@@ -13,7 +14,7 @@ def tesla_tester():
   # Now set the panda from its default of SAFETY_SILENT (read only) to SAFETY_ALLOUTPUT
   # Careful, as this will let us send any CAN messages we want (which could be very bad!)
   print("Setting Panda to output mode...")
-  p.set_safety_mode(Panda.SAFETY_ALLOUTPUT)
+  p.set_safety_mode(Safety.SAFETY_ALLOUTPUT)
 
   # BDY 0x248 is the MCU_commands message, which includes folding mirrors, opening the trunk, frunk, setting the cars lock state and more.
   # For our test, we will edit the 3rd byte, which is MCU_lockRequest. 0x01 will lock, 0x02 will unlock:
@@ -26,7 +27,7 @@ def tesla_tester():
 
   #Back to safety...
   print("Disabling output on Panda...")
-  p.set_safety_mode(Panda.SAFETY_SILENT)
+  p.set_safety_mode(Safety.SAFETY_SILENT)
 
   print("Reading VIN from 0x568. This is painfully slow and can take up to 3 minutes (1 minute per message; 3 messages needed for full VIN)...")
 

--- a/python/__init__.py
+++ b/python/__init__.py
@@ -101,46 +101,7 @@ ensure_health_packet_version = partial(ensure_version, "health", "HEALTH_PACKET_
 
 
 
-class ALTERNATIVE_EXPERIENCE:
-  DEFAULT = 0
-  DISABLE_DISENGAGE_ON_GAS = 1
-  DISABLE_STOCK_AEB = 2
-  RAISE_LONGITUDINAL_LIMITS_TO_ISO_MAX = 8
-  ALLOW_AEB = 16
-
-  # sunnypilot
-  ENABLE_MADS = 2 ** 10
-  DISENGAGE_LATERAL_ON_BRAKE = 2 ** 11
-
 class Panda:
-
-  # matches cereal.car.CarParams.SafetyModel
-  SAFETY_SILENT = 0
-  SAFETY_HONDA_NIDEC = 1
-  SAFETY_TOYOTA = 2
-  SAFETY_ELM327 = 3
-  SAFETY_GM = 4
-  SAFETY_HONDA_BOSCH_GIRAFFE = 5
-  SAFETY_FORD = 6
-  SAFETY_HYUNDAI = 8
-  SAFETY_CHRYSLER = 9
-  SAFETY_TESLA = 10
-  SAFETY_SUBARU = 11
-  SAFETY_MAZDA = 13
-  SAFETY_NISSAN = 14
-  SAFETY_VOLKSWAGEN_MQB = 15
-  SAFETY_ALLOUTPUT = 17
-  SAFETY_GM_ASCM = 18
-  SAFETY_NOOUTPUT = 19
-  SAFETY_HONDA_BOSCH = 20
-  SAFETY_VOLKSWAGEN_PQ = 21
-  SAFETY_SUBARU_PREGLOBAL = 22
-  SAFETY_HYUNDAI_LEGACY = 23
-  SAFETY_HYUNDAI_COMMUNITY = 24
-  SAFETY_STELLANTIS = 25
-  SAFETY_FAW = 26
-  SAFETY_BODY = 27
-  SAFETY_HYUNDAI_CANFD = 28
 
   SERIAL_DEBUG = 0
   SERIAL_ESP = 1
@@ -187,50 +148,6 @@ class Panda:
   HARNESS_STATUS_NC = 0
   HARNESS_STATUS_NORMAL = 1
   HARNESS_STATUS_FLIPPED = 2
-
-  # first byte is for EPS scaling factor
-  FLAG_TOYOTA_ALT_BRAKE = (1 << 8)
-  FLAG_TOYOTA_STOCK_LONGITUDINAL = (2 << 8)
-  FLAG_TOYOTA_LTA = (4 << 8)
-  FLAG_TOYOTA_SECOC = (8 << 8)
-
-  FLAG_HONDA_ALT_BRAKE = 1
-  FLAG_HONDA_BOSCH_LONG = 2
-  FLAG_HONDA_NIDEC_ALT = 4
-  FLAG_HONDA_RADARLESS = 8
-
-  FLAG_HYUNDAI_EV_GAS = 1
-  FLAG_HYUNDAI_HYBRID_GAS = 2
-  FLAG_HYUNDAI_LONG = 4
-  FLAG_HYUNDAI_CAMERA_SCC = 8
-  FLAG_HYUNDAI_CANFD_HDA2 = 16
-  FLAG_HYUNDAI_CANFD_ALT_BUTTONS = 32
-  FLAG_HYUNDAI_ALT_LIMITS = 64
-  FLAG_HYUNDAI_CANFD_HDA2_ALT_STEERING = 128
-  FLAG_HYUNDAI_ESCC = 512
-  FLAG_HYUNDAI_LONG_MAIN_CRUISE_TOGGLEABLE = 1024
-
-  FLAG_TESLA_POWERTRAIN = 1
-  FLAG_TESLA_LONG_CONTROL = 2
-  FLAG_TESLA_RAVEN = 4
-
-  FLAG_VOLKSWAGEN_LONG_CONTROL = 1
-
-  FLAG_CHRYSLER_RAM_DT = 1
-  FLAG_CHRYSLER_RAM_HD = 2
-
-  FLAG_SUBARU_GEN2 = 1
-  FLAG_SUBARU_LONG = 2
-  FLAG_SUBARU_PREGLOBAL_REVERSED_DRIVER_TORQUE = 4
-
-  FLAG_NISSAN_ALT_EPS_BUS = 1
-  FLAG_NISSAN_LEAF = 512
-
-  FLAG_GM_HW_CAM = 1
-  FLAG_GM_HW_CAM_LONG = 2
-
-  FLAG_FORD_LONG_CONTROL = 1
-  FLAG_FORD_CANFD = 2
 
   def __init__(self, serial: str | None = None, claim: bool = True, disable_checks: bool = True, can_speed_kbps: int = 500, cli: bool = True):
     self._disable_checks = disable_checks
@@ -795,7 +712,7 @@ class Panda:
   def set_power_save(self, power_save_enabled=0):
     self._handle.controlWrite(Panda.REQUEST_OUT, 0xe7, int(power_save_enabled), 0, b'')
 
-  def set_safety_mode(self, mode=SAFETY_SILENT, param=0):
+  def set_safety_mode(self, mode=0, param=0):  # Safety.SAFETY_SILENT
     self._handle.controlWrite(Panda.REQUEST_OUT, 0xdc, mode, param, b'')
 
   def set_obd(self, obd):

--- a/tests/black_white_loopback_test.py
+++ b/tests/black_white_loopback_test.py
@@ -9,6 +9,7 @@ import os
 import time
 import random
 import argparse
+from opendbc.safety import Safety
 from panda import Panda
 
 def get_test_string():
@@ -47,8 +48,8 @@ def run_test(sleep_duration):
     raise Exception("Connect white/grey and black panda to run this test!")
 
   # disable safety modes
-  black_panda.set_safety_mode(Panda.SAFETY_ALLOUTPUT)
-  other_panda.set_safety_mode(Panda.SAFETY_ALLOUTPUT)
+  black_panda.set_safety_mode(Safety.SAFETY_ALLOUTPUT)
+  other_panda.set_safety_mode(Safety.SAFETY_ALLOUTPUT)
 
   # test health packet
   print("black panda health", black_panda.health())
@@ -62,9 +63,9 @@ def run_test(sleep_duration):
     print("Number of cycles:", counter, "Non-zero bus errors:", nonzero_bus_errors, "Zero bus errors:", zero_bus_errors, "Content errors:", content_errors)
 
     # Toggle relay
-    black_panda.set_safety_mode(Panda.SAFETY_SILENT)
+    black_panda.set_safety_mode(Safety.SAFETY_SILENT)
     time.sleep(1)
-    black_panda.set_safety_mode(Panda.SAFETY_ALLOUTPUT)
+    black_panda.set_safety_mode(Safety.SAFETY_ALLOUTPUT)
     time.sleep(1)
 
 

--- a/tests/black_white_relay_endurance.py
+++ b/tests/black_white_relay_endurance.py
@@ -10,6 +10,7 @@ import time
 import random
 import argparse
 
+from opendbc.safety import Safety
 from panda import Panda
 
 def get_test_string():
@@ -48,8 +49,8 @@ def run_test(sleep_duration):
     raise Exception("Connect white/grey and black panda to run this test!")
 
   # disable safety modes
-  black_panda.set_safety_mode(Panda.SAFETY_ALLOUTPUT)
-  other_panda.set_safety_mode(Panda.SAFETY_ALLOUTPUT)
+  black_panda.set_safety_mode(Safety.SAFETY_ALLOUTPUT)
+  other_panda.set_safety_mode(Safety.SAFETY_ALLOUTPUT)
 
   # test health packet
   print("black panda health", black_panda.health())
@@ -69,9 +70,9 @@ def run_test(sleep_duration):
 
     if (time.time() - temp_start_time) > 3600 * 6:
       # Toggle relay
-      black_panda.set_safety_mode(Panda.SAFETY_SILENT)
+      black_panda.set_safety_mode(Safety.SAFETY_SILENT)
       time.sleep(1)
-      black_panda.set_safety_mode(Panda.SAFETY_ALLOUTPUT)
+      black_panda.set_safety_mode(Safety.SAFETY_ALLOUTPUT)
       time.sleep(1)
       temp_start_time = time.time()
 

--- a/tests/black_white_relay_test.py
+++ b/tests/black_white_relay_test.py
@@ -9,6 +9,7 @@ import time
 import random
 import argparse
 
+from opendbc.safety import Safety
 from panda import Panda
 
 def get_test_string():
@@ -50,8 +51,8 @@ def run_test(sleep_duration):
     raise Exception("Connect white/grey and black panda to run this test!")
 
   # disable safety modes
-  black_panda.set_safety_mode(Panda.SAFETY_ALLOUTPUT)
-  other_panda.set_safety_mode(Panda.SAFETY_ALLOUTPUT)
+  black_panda.set_safety_mode(Safety.SAFETY_ALLOUTPUT)
+  other_panda.set_safety_mode(Safety.SAFETY_ALLOUTPUT)
 
   # test health packet
   print("black panda health", black_panda.health())
@@ -60,7 +61,7 @@ def run_test(sleep_duration):
   # test black -> other
   while True:
     # Switch on relay
-    black_panda.set_safety_mode(Panda.SAFETY_ALLOUTPUT)
+    black_panda.set_safety_mode(Safety.SAFETY_ALLOUTPUT)
     time.sleep(0.05)
 
     if not test_buses(black_panda, other_panda, (0, False, [0])):
@@ -68,7 +69,7 @@ def run_test(sleep_duration):
       raise Exception("Open error")
 
     # Switch off relay
-    black_panda.set_safety_mode(Panda.SAFETY_SILENT)
+    black_panda.set_safety_mode(Safety.SAFETY_SILENT)
     time.sleep(0.05)
 
     if not test_buses(black_panda, other_panda, (0, False, [0, 2])):

--- a/tests/bulk_write_test.py
+++ b/tests/bulk_write_test.py
@@ -4,6 +4,7 @@ import time
 import threading
 from typing import Any
 
+from opendbc.safety import Safety
 from panda import Panda
 
 JUNGLE = "JUNGLE" in os.environ
@@ -30,9 +31,9 @@ if __name__ == "__main__":
       raise Exception("Connect two pandas to perform this test!")
     sender = Panda(serials[0])
     receiver = Panda(serials[1])  # type: ignore
-    receiver.set_safety_mode(Panda.SAFETY_ALLOUTPUT)
+    receiver.set_safety_mode(Safety.SAFETY_ALLOUTPUT)
 
-  sender.set_safety_mode(Panda.SAFETY_ALLOUTPUT)
+  sender.set_safety_mode(Safety.SAFETY_ALLOUTPUT)
 
   # Start transmisson
   threading.Thread(target=flood_tx, args=(sender,)).start()

--- a/tests/can_printer.py
+++ b/tests/can_printer.py
@@ -4,6 +4,7 @@ import time
 from collections import defaultdict
 import binascii
 
+from opendbc.safety import Safety
 from panda import Panda
 
 # fake
@@ -16,7 +17,7 @@ def can_printer():
   time.sleep(1)
 
   p.can_clear(0xFFFF)
-  p.set_safety_mode(Panda.SAFETY_ALLOUTPUT)
+  p.set_safety_mode(Safety.SAFETY_ALLOUTPUT)
 
   start = sec_since_boot()
   lp = sec_since_boot()

--- a/tests/canfd/test_canfd.py
+++ b/tests/canfd/test_canfd.py
@@ -3,6 +3,7 @@ import os
 import time
 import random
 from collections import defaultdict
+from opendbc.safety import Safety
 from panda import Panda, calculate_checksum, DLC_TO_LEN
 from panda import PandaJungle
 from panda.tests.hitl.helpers import time_many_sends
@@ -44,14 +45,14 @@ def panda_init(serial, enable_canfd=False, enable_non_iso=False):
       p.set_can_data_speed_kbps(bus, 2000)
     if enable_non_iso:
       p.set_canfd_non_iso(bus, True)
-  p.set_safety_mode(Panda.SAFETY_ALLOUTPUT)
+  p.set_safety_mode(Safety.SAFETY_ALLOUTPUT)
   return p
 
 def test_canfd_throughput(p, p_recv=None):
   two_pandas = p_recv is not None
-  p.set_safety_mode(Panda.SAFETY_ALLOUTPUT)
+  p.set_safety_mode(Safety.SAFETY_ALLOUTPUT)
   if two_pandas:
-    p_recv.set_safety_mode(Panda.SAFETY_ALLOUTPUT)
+    p_recv.set_safety_mode(Safety.SAFETY_ALLOUTPUT)
   # enable output mode
   else:
     p.set_can_loopback(True)

--- a/tests/echo.py
+++ b/tests/echo.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python3
+from opendbc.safety import Safety
 from panda import Panda
 
 # This script is intended to be used in conjunction with the echo_loopback_test.py test script from panda jungle.
 # It sends a reversed response back for every message received containing b"test".
 if __name__ == "__main__":
   p = Panda()
-  p.set_safety_mode(Panda.SAFETY_ALLOUTPUT)
+  p.set_safety_mode(Safety.SAFETY_ALLOUTPUT)
   p.set_power_save(False)
 
   while True:

--- a/tests/elm_car_simulator.py
+++ b/tests/elm_car_simulator.py
@@ -10,6 +10,7 @@ import time
 import threading
 from collections import deque
 
+from opendbc.safety import Safety
 from panda import Panda
 
 def lin_checksum(dat):
@@ -61,7 +62,7 @@ class ELMCarSimulator():
         self.__on = on
 
     def start(self):
-        self.panda.set_safety_mode(Panda.SAFETY_ALLOUTPUT)
+        self.panda.set_safety_mode(Safety.SAFETY_ALLOUTPUT)
         if self.__lin_enable:
             self.__lin_monitor_thread.start()
         if self.__can_enable:

--- a/tests/hitl/2_health.py
+++ b/tests/hitl/2_health.py
@@ -1,6 +1,8 @@
 import time
 import pytest
 
+from opendbc.car.hyundai.values import HyundaiSafetyFlags
+from opendbc.safety import Safety
 from panda import Panda
 
 
@@ -36,10 +38,10 @@ def test_hw_type(p):
 def test_heartbeat(p, panda_jungle):
   panda_jungle.set_ignition(True)
   # TODO: add more cases here once the tests aren't super slow
-  p.set_safety_mode(mode=Panda.SAFETY_HYUNDAI, param=Panda.FLAG_HYUNDAI_LONG)
+  p.set_safety_mode(mode=Safety.SAFETY_HYUNDAI, param=HyundaiSafetyFlags.FLAG_HYUNDAI_LONG)
   p.send_heartbeat()
-  assert p.health()['safety_mode'] == Panda.SAFETY_HYUNDAI
-  assert p.health()['safety_param'] == Panda.FLAG_HYUNDAI_LONG
+  assert p.health()['safety_mode'] == Safety.SAFETY_HYUNDAI
+  assert p.health()['safety_param'] == HyundaiSafetyFlags.FLAG_HYUNDAI_LONG
 
   # shouldn't do anything once we're in a car safety mode
   p.set_heartbeat_disabled()
@@ -48,7 +50,7 @@ def test_heartbeat(p, panda_jungle):
 
   h = p.health()
   assert h['heartbeat_lost']
-  assert h['safety_mode'] == Panda.SAFETY_SILENT
+  assert h['safety_mode'] == Safety.SAFETY_SILENT
   assert h['safety_param'] == 0
   assert h['controls_allowed'] == 0
 

--- a/tests/hitl/3_usb_to_can.py
+++ b/tests/hitl/3_usb_to_can.py
@@ -1,11 +1,12 @@
 import time
 from flaky import flaky
 
+from opendbc.safety import Safety
 from panda import Panda
 from panda.tests.hitl.helpers import time_many_sends
 
 def test_can_loopback(p):
-  p.set_safety_mode(Panda.SAFETY_ALLOUTPUT)
+  p.set_safety_mode(Safety.SAFETY_ALLOUTPUT)
   p.set_can_loopback(True)
 
   for bus in (0, 1, 2):
@@ -30,7 +31,7 @@ def test_can_loopback(p):
 def test_reliability(p):
   MSG_COUNT = 100
 
-  p.set_safety_mode(Panda.SAFETY_ALLOUTPUT)
+  p.set_safety_mode(Safety.SAFETY_ALLOUTPUT)
   p.set_can_loopback(True)
   p.set_can_speed_kbps(0, 1000)
 
@@ -60,7 +61,7 @@ def test_reliability(p):
 @flaky(max_runs=6, min_passes=1)
 def test_throughput(p):
   # enable output mode
-  p.set_safety_mode(Panda.SAFETY_ALLOUTPUT)
+  p.set_safety_mode(Safety.SAFETY_ALLOUTPUT)
 
   # enable CAN loopback mode
   p.set_can_loopback(True)

--- a/tests/hitl/4_can_loopback.py
+++ b/tests/hitl/4_can_loopback.py
@@ -6,7 +6,7 @@ import threading
 from flaky import flaky
 from collections import defaultdict
 
-from panda import Panda
+from opendbc.safety import Safety
 from panda.tests.hitl.conftest import PandaGroup
 from panda.tests.hitl.helpers import time_many_sends, get_random_can_messages, clear_can_buffers
 
@@ -27,7 +27,7 @@ def test_send_recv(p, panda_jungle):
         print(f"two pandas bus {bus}, 100 messages at speed {speed:4d}, comp speed is {comp_kbps:7.2f}, {saturation_pct:6.2f}%")
 
   # Run tests in both directions
-  p.set_safety_mode(Panda.SAFETY_ALLOUTPUT)
+  p.set_safety_mode(Safety.SAFETY_ALLOUTPUT)
   test(p, panda_jungle)
   test(panda_jungle, p)
 
@@ -84,7 +84,7 @@ def test_latency(p, panda_jungle):
               .format(bus, num_messages, speed, average_latency, average_comp_kbps, average_saturation_pct))
 
   # Run tests in both directions
-  p.set_safety_mode(Panda.SAFETY_ALLOUTPUT)
+  p.set_safety_mode(Safety.SAFETY_ALLOUTPUT)
   test(p, panda_jungle)
   test(panda_jungle, p)
 
@@ -126,12 +126,12 @@ def test_gen2_loopback(p, panda_jungle):
       print("Bus:", bus, "address:", addr, "OBD:", obd, "OK")
 
   # Run tests in both directions
-  p.set_safety_mode(Panda.SAFETY_ALLOUTPUT)
+  p.set_safety_mode(Safety.SAFETY_ALLOUTPUT)
   test(p, panda_jungle)
   test(panda_jungle, p)
 
   # Test extended frame address with ELM327 mode
-  p.set_safety_mode(Panda.SAFETY_ELM327)
+  p.set_safety_mode(Safety.SAFETY_ELM327)
   test(p, panda_jungle, 0x18DB33F1)
   test(panda_jungle, p, 0x18DB33F1)
 
@@ -153,7 +153,7 @@ def test_bulk_write(p, panda_jungle):
     packet += [[0xaa, msg, 0], [0xaa, msg, 1], [0xaa, msg, 2]] * NUM_MESSAGES_PER_BUS
 
     # Disable timeout
-    panda.set_safety_mode(Panda.SAFETY_ALLOUTPUT)
+    panda.set_safety_mode(Safety.SAFETY_ALLOUTPUT)
     panda.can_send_many(packet, timeout=0)
     print(f"Done sending {4 * NUM_MESSAGES_PER_BUS} messages!", time.monotonic())
     print(panda.health())
@@ -175,7 +175,7 @@ def test_bulk_write(p, panda_jungle):
     raise Exception("Did not receive all messages!")
 
 def test_message_integrity(p):
-  p.set_safety_mode(Panda.SAFETY_ALLOUTPUT)
+  p.set_safety_mode(Safety.SAFETY_ALLOUTPUT)
   p.set_can_loopback(True)
   for i in range(250):
     sent_msgs = defaultdict(set)

--- a/tests/hitl/6_safety.py
+++ b/tests/hitl/6_safety.py
@@ -1,10 +1,11 @@
 import time
 
+from opendbc.safety import Safety
 from panda import Panda
 
 
 def test_safety_nooutput(p):
-  p.set_safety_mode(Panda.SAFETY_SILENT)
+  p.set_safety_mode(Safety.SAFETY_SILENT)
   p.set_can_loopback(True)
 
   # send a message on bus 0
@@ -20,10 +21,10 @@ def test_safety_nooutput(p):
 
 def test_canfd_safety_modes(p):
   # works on all pandas
-  p.set_safety_mode(Panda.SAFETY_TOYOTA)
-  assert p.health()['safety_mode'] == Panda.SAFETY_TOYOTA
+  p.set_safety_mode(Safety.SAFETY_TOYOTA)
+  assert p.health()['safety_mode'] == Safety.SAFETY_TOYOTA
 
   # shouldn't be able to set a CAN-FD safety mode on non CAN-FD panda
-  p.set_safety_mode(Panda.SAFETY_HYUNDAI_CANFD)
-  expected_mode = Panda.SAFETY_HYUNDAI_CANFD if p.get_type() in Panda.H7_DEVICES else Panda.SAFETY_SILENT
+  p.set_safety_mode(Safety.SAFETY_HYUNDAI_CANFD)
+  expected_mode = Safety.SAFETY_HYUNDAI_CANFD if p.get_type() in Panda.H7_DEVICES else Safety.SAFETY_SILENT
   assert p.health()['safety_mode'] == expected_mode

--- a/tests/hitl/9_harness.py
+++ b/tests/hitl/9_harness.py
@@ -2,6 +2,7 @@ import time
 import pytest
 import itertools
 
+from opendbc.safety import Safety
 from panda import Panda
 from panda.tests.hitl.conftest import PandaGroup
 
@@ -19,7 +20,7 @@ def test_harness_status(p, panda_jungle):
   # between the tests.
   for ignition, orientation in itertools.product([True, False], [Panda.HARNESS_STATUS_NC, Panda.HARNESS_STATUS_NORMAL, Panda.HARNESS_STATUS_FLIPPED]):
     print()
-    p.set_safety_mode(Panda.SAFETY_ELM327)
+    p.set_safety_mode(Safety.SAFETY_ELM327)
     panda_jungle.set_harness_orientation(orientation)
     panda_jungle.set_ignition(ignition)
 

--- a/tests/loopback_test.py
+++ b/tests/loopback_test.py
@@ -6,6 +6,7 @@ import random
 import argparse
 from itertools import permutations
 
+from opendbc.safety import Safety
 from panda import Panda
 
 def get_test_string():
@@ -25,7 +26,7 @@ def run_test_w_pandas(pandas, sleep_duration):
   print("H", h)
 
   for hh in h:
-    hh.set_safety_mode(Panda.SAFETY_ALLOUTPUT)
+    hh.set_safety_mode(Safety.SAFETY_ALLOUTPUT)
 
   # test both directions
   for ho in permutations(list(range(len(h))), r=2):

--- a/tests/message_drop_test.py
+++ b/tests/message_drop_test.py
@@ -7,6 +7,7 @@ import itertools
 import threading
 from typing import Any
 
+from opendbc.safety import Safety
 from panda import Panda
 
 JUNGLE = "JUNGLE" in os.environ
@@ -44,9 +45,9 @@ if __name__ == "__main__":
       raise Exception("Connect two pandas to perform this test!")
     sender = Panda(serials[0])
     receiver = Panda(serials[1])
-    receiver.set_safety_mode(Panda.SAFETY_ALLOUTPUT)
+    receiver.set_safety_mode(Safety.SAFETY_ALLOUTPUT)
 
-  sender.set_safety_mode(Panda.SAFETY_ALLOUTPUT)
+  sender.set_safety_mode(Safety.SAFETY_ALLOUTPUT)
 
   # Start transmisson
   threading.Thread(target=flood_tx, args=(sender,)).start()

--- a/tests/relay_test.py
+++ b/tests/relay_test.py
@@ -1,15 +1,16 @@
 #!/usr/bin/env python
 import time
+from opendbc.safety import Safety
 from panda import Panda
 
 p = Panda()
 
 while True:
-  p.set_safety_mode(Panda.SAFETY_TOYOTA)
+  p.set_safety_mode(Safety.SAFETY_TOYOTA)
   p.send_heartbeat()
   print("ON")
   time.sleep(1)
-  p.set_safety_mode(Panda.SAFETY_NOOUTPUT)
+  p.set_safety_mode(Safety.SAFETY_NOOUTPUT)
   p.send_heartbeat()
   print("OFF")
   time.sleep(1)

--- a/tests/safety/common.py
+++ b/tests/safety/common.py
@@ -6,7 +6,7 @@ import numpy as np
 from collections.abc import Callable
 
 from opendbc.can.packer import CANPacker  # pylint: disable=import-error
-from panda import ALTERNATIVE_EXPERIENCE
+from opendbc.safety import ALTERNATIVE_EXPERIENCE
 from panda.tests.libpanda import libpanda_py
 from panda.tests.safety.mads_common import MadsCommonBase
 

--- a/tests/safety/hyundai_common.py
+++ b/tests/safety/hyundai_common.py
@@ -1,9 +1,9 @@
 import unittest
 
+from opendbc.car.hyundai.values import HyundaiSafetyFlags
 import panda.tests.safety.common as common
 from panda.tests.libpanda import libpanda_py
 from panda.tests.safety.common import make_msg
-from panda import Panda
 
 
 class Buttons:
@@ -148,7 +148,7 @@ class HyundaiLongitudinalBase(common.LongitudinalAccelSafetyTest):
       with self.subTest("enable_mads", mads_enabled=enable_mads):
         for main_cruise_toggleable in (True, False):
           with self.subTest("main_cruise_toggleable", main_cruise_toggleable=main_cruise_toggleable):
-            main_cruise_toggleable_flag = Panda.FLAG_HYUNDAI_LONG_MAIN_CRUISE_TOGGLEABLE if main_cruise_toggleable else 0
+            main_cruise_toggleable_flag = HyundaiSafetyFlags.FLAG_HYUNDAI_LONG_MAIN_CRUISE_TOGGLEABLE if main_cruise_toggleable else 0
             self.safety.set_safety_hooks(default_safety_mode, default_safety_param | main_cruise_toggleable_flag)
 
             # Test initial state
@@ -180,7 +180,7 @@ class HyundaiLongitudinalBase(common.LongitudinalAccelSafetyTest):
 
     for enable_mads in (True, False):
       with self.subTest("enable_mads", mads_enabled=enable_mads):
-        main_cruise_toggleable_flag = Panda.FLAG_HYUNDAI_LONG_MAIN_CRUISE_TOGGLEABLE
+        main_cruise_toggleable_flag = HyundaiSafetyFlags.FLAG_HYUNDAI_LONG_MAIN_CRUISE_TOGGLEABLE
         self.safety.set_safety_hooks(default_safety_mode, default_safety_param | main_cruise_toggleable_flag)
 
         self._mads_states_cleanup()
@@ -213,7 +213,7 @@ class HyundaiLongitudinalBase(common.LongitudinalAccelSafetyTest):
 
     for enable_mads in (True, False):
       with self.subTest("enable_mads", mads_enabled=enable_mads):
-        main_cruise_toggleable_flag = Panda.FLAG_HYUNDAI_LONG_MAIN_CRUISE_TOGGLEABLE
+        main_cruise_toggleable_flag = HyundaiSafetyFlags.FLAG_HYUNDAI_LONG_MAIN_CRUISE_TOGGLEABLE
         self.safety.set_safety_hooks(default_safety_mode, default_safety_param | main_cruise_toggleable_flag)
 
         self._mads_states_cleanup()
@@ -254,7 +254,7 @@ class HyundaiLongitudinalBase(common.LongitudinalAccelSafetyTest):
     """Test that mismatch counter resets when states resync"""
     for enable_mads in (True, False):
       with self.subTest("enable_mads", mads_enabled=enable_mads):
-        main_cruise_toggleable_flag = Panda.FLAG_HYUNDAI_LONG_MAIN_CRUISE_TOGGLEABLE
+        main_cruise_toggleable_flag = HyundaiSafetyFlags.FLAG_HYUNDAI_LONG_MAIN_CRUISE_TOGGLEABLE
         self.safety.set_safety_hooks(default_safety_mode, default_safety_param | main_cruise_toggleable_flag)
 
         self._mads_states_cleanup()

--- a/tests/safety/test_body.py
+++ b/tests/safety/test_body.py
@@ -3,7 +3,7 @@ import unittest
 
 import panda.tests.safety.common as common
 
-from panda import Panda
+from opendbc.safety import Safety
 from panda.tests.libpanda import libpanda_py
 from panda.tests.safety.common import CANPackerPanda
 
@@ -15,7 +15,7 @@ class TestBody(common.PandaSafetyTest):
   def setUp(self):
     self.packer = CANPackerPanda("comma_body")
     self.safety = libpanda_py.libpanda
-    self.safety.set_safety_hooks(Panda.SAFETY_BODY, 0)
+    self.safety.set_safety_hooks(Safety.SAFETY_BODY, 0)
     self.safety.init_tests()
 
   def _motors_data_msg(self, speed_l, speed_r):

--- a/tests/safety/test_chrysler.py
+++ b/tests/safety/test_chrysler.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 import unittest
-from panda import Panda
+
+from opendbc.car.chrysler.values import ChryslerSafetyFlags
+from opendbc.safety import Safety
 from panda.tests.libpanda import libpanda_py
 import panda.tests.safety.common as common
 from panda.tests.safety.common import CANPackerPanda
@@ -27,7 +29,7 @@ class TestChryslerSafety(common.PandaCarSafetyTest, common.MotorTorqueSteeringSa
   def setUp(self):
     self.packer = CANPackerPanda("chrysler_pacifica_2017_hybrid_generated")
     self.safety = libpanda_py.libpanda
-    self.safety.set_safety_hooks(Panda.SAFETY_CHRYSLER, 0)
+    self.safety.set_safety_hooks(Safety.SAFETY_CHRYSLER, 0)
     self.safety.init_tests()
 
   def _button_msg(self, cancel=False, resume=False):
@@ -97,7 +99,7 @@ class TestChryslerRamDTSafety(TestChryslerSafety):
   def setUp(self):
     self.packer = CANPackerPanda("chrysler_ram_dt_generated")
     self.safety = libpanda_py.libpanda
-    self.safety.set_safety_hooks(Panda.SAFETY_CHRYSLER, Panda.FLAG_CHRYSLER_RAM_DT)
+    self.safety.set_safety_hooks(Safety.SAFETY_CHRYSLER, ChryslerSafetyFlags.FLAG_CHRYSLER_RAM_DT)
     self.safety.init_tests()
 
   def _speed_msg(self, speed):
@@ -125,7 +127,7 @@ class TestChryslerRamHDSafety(TestChryslerSafety):
   def setUp(self):
     self.packer = CANPackerPanda("chrysler_ram_hd_generated")
     self.safety = libpanda_py.libpanda
-    self.safety.set_safety_hooks(Panda.SAFETY_CHRYSLER, Panda.FLAG_CHRYSLER_RAM_HD)
+    self.safety.set_safety_hooks(Safety.SAFETY_CHRYSLER, ChryslerSafetyFlags.FLAG_CHRYSLER_RAM_HD)
     self.safety.init_tests()
 
   def _speed_msg(self, speed):

--- a/tests/safety/test_defaults.py
+++ b/tests/safety/test_defaults.py
@@ -3,7 +3,7 @@ import unittest
 
 import panda.tests.safety.common as common
 
-from panda import Panda
+from opendbc.safety import Safety
 from panda.tests.libpanda import libpanda_py
 
 
@@ -20,7 +20,7 @@ class TestNoOutput(TestDefaultRxHookBase):
 
   def setUp(self):
     self.safety = libpanda_py.libpanda
-    self.safety.set_safety_hooks(Panda.SAFETY_NOOUTPUT, 0)
+    self.safety.set_safety_hooks(Safety.SAFETY_NOOUTPUT, 0)
     self.safety.init_tests()
 
 
@@ -29,7 +29,7 @@ class TestSilent(TestNoOutput):
 
   def setUp(self):
     self.safety = libpanda_py.libpanda
-    self.safety.set_safety_hooks(Panda.SAFETY_SILENT, 0)
+    self.safety.set_safety_hooks(Safety.SAFETY_SILENT, 0)
     self.safety.init_tests()
 
 
@@ -40,7 +40,7 @@ class TestAllOutput(TestDefaultRxHookBase):
 
   def setUp(self):
     self.safety = libpanda_py.libpanda
-    self.safety.set_safety_hooks(Panda.SAFETY_ALLOUTPUT, 0)
+    self.safety.set_safety_hooks(Safety.SAFETY_ALLOUTPUT, 0)
     self.safety.init_tests()
 
   def test_spam_can_buses(self):
@@ -65,7 +65,7 @@ class TestAllOutputPassthrough(TestAllOutput):
 
   def setUp(self):
     self.safety = libpanda_py.libpanda
-    self.safety.set_safety_hooks(Panda.SAFETY_ALLOUTPUT, 1)
+    self.safety.set_safety_hooks(Safety.SAFETY_ALLOUTPUT, 1)
     self.safety.init_tests()
 
 

--- a/tests/safety/test_elm327.py
+++ b/tests/safety/test_elm327.py
@@ -3,7 +3,8 @@ import unittest
 
 import panda.tests.safety.common as common
 
-from panda import DLC_TO_LEN, Panda
+from opendbc.safety import Safety
+from panda import DLC_TO_LEN
 from panda.tests.libpanda import libpanda_py
 from panda.tests.safety.test_defaults import TestDefaultRxHookBase
 
@@ -18,7 +19,7 @@ class TestElm327(TestDefaultRxHookBase):
 
   def setUp(self):
     self.safety = libpanda_py.libpanda
-    self.safety.set_safety_hooks(Panda.SAFETY_ELM327, 0)
+    self.safety.set_safety_hooks(Safety.SAFETY_ELM327, 0)
     self.safety.init_tests()
 
   def test_tx_hook(self):

--- a/tests/safety/test_ford.py
+++ b/tests/safety/test_ford.py
@@ -4,8 +4,9 @@ import random
 import unittest
 
 import panda.tests.safety.common as common
+from opendbc.car.ford.values import FordSafetyFlags
 
-from panda import Panda
+from opendbc.safety import Safety
 from panda.tests.libpanda import libpanda_py
 from panda.tests.safety.common import CANPackerPanda
 
@@ -378,7 +379,7 @@ class TestFordCANFDStockSafety(TestFordSafetyBase):
   def setUp(self):
     self.packer = CANPackerPanda("ford_lincoln_base_pt")
     self.safety = libpanda_py.libpanda
-    self.safety.set_safety_hooks(Panda.SAFETY_FORD, Panda.FLAG_FORD_CANFD)
+    self.safety.set_safety_hooks(Safety.SAFETY_FORD, FordSafetyFlags.FLAG_FORD_CANFD)
     self.safety.init_tests()
 
 
@@ -455,7 +456,7 @@ class TestFordLongitudinalSafety(TestFordLongitudinalSafetyBase):
     self.packer = CANPackerPanda("ford_lincoln_base_pt")
     self.safety = libpanda_py.libpanda
     # Make sure we enforce long safety even without long flag for CAN
-    self.safety.set_safety_hooks(Panda.SAFETY_FORD, 0)
+    self.safety.set_safety_hooks(Safety.SAFETY_FORD, 0)
     self.safety.init_tests()
 
 
@@ -470,7 +471,7 @@ class TestFordCANFDLongitudinalSafety(TestFordLongitudinalSafetyBase):
   def setUp(self):
     self.packer = CANPackerPanda("ford_lincoln_base_pt")
     self.safety = libpanda_py.libpanda
-    self.safety.set_safety_hooks(Panda.SAFETY_FORD, Panda.FLAG_FORD_LONG_CONTROL | Panda.FLAG_FORD_CANFD)
+    self.safety.set_safety_hooks(Safety.SAFETY_FORD, FordSafetyFlags.FLAG_FORD_LONG_CONTROL | FordSafetyFlags.FLAG_FORD_CANFD)
     self.safety.init_tests()
 
 

--- a/tests/safety/test_gm.py
+++ b/tests/safety/test_gm.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 import unittest
-from panda import Panda
+
+from opendbc.car.gm.values import GMSafetyFlags
+from opendbc.safety import Safety
 from panda.tests.libpanda import libpanda_py
 import panda.tests.safety.common as common
 from panda.tests.safety.common import CANPackerPanda
@@ -97,7 +99,7 @@ class TestGmSafetyBase(common.PandaCarSafetyTest, common.DriverTorqueSteeringSaf
     self.packer = CANPackerPanda("gm_global_a_powertrain_generated")
     self.packer_chassis = CANPackerPanda("gm_global_a_chassis")
     self.safety = libpanda_py.libpanda
-    self.safety.set_safety_hooks(Panda.SAFETY_GM, 0)
+    self.safety.set_safety_hooks(Safety.SAFETY_GM, 0)
     self.safety.init_tests()
 
   def _pcm_status_msg(self, enable):
@@ -157,7 +159,7 @@ class TestGmAscmSafety(GmLongitudinalBase, TestGmSafetyBase):
     self.packer = CANPackerPanda("gm_global_a_powertrain_generated")
     self.packer_chassis = CANPackerPanda("gm_global_a_chassis")
     self.safety = libpanda_py.libpanda
-    self.safety.set_safety_hooks(Panda.SAFETY_GM, 0)
+    self.safety.set_safety_hooks(Safety.SAFETY_GM, 0)
     self.safety.init_tests()
 
 
@@ -187,7 +189,7 @@ class TestGmCameraSafety(TestGmCameraSafetyBase):
     self.packer = CANPackerPanda("gm_global_a_powertrain_generated")
     self.packer_chassis = CANPackerPanda("gm_global_a_chassis")
     self.safety = libpanda_py.libpanda
-    self.safety.set_safety_hooks(Panda.SAFETY_GM, Panda.FLAG_GM_HW_CAM)
+    self.safety.set_safety_hooks(Safety.SAFETY_GM, GMSafetyFlags.FLAG_GM_HW_CAM)
     self.safety.init_tests()
 
   def test_buttons(self):
@@ -219,7 +221,7 @@ class TestGmCameraLongitudinalSafety(GmLongitudinalBase, TestGmCameraSafetyBase)
     self.packer = CANPackerPanda("gm_global_a_powertrain_generated")
     self.packer_chassis = CANPackerPanda("gm_global_a_chassis")
     self.safety = libpanda_py.libpanda
-    self.safety.set_safety_hooks(Panda.SAFETY_GM, Panda.FLAG_GM_HW_CAM | Panda.FLAG_GM_HW_CAM_LONG)
+    self.safety.set_safety_hooks(Safety.SAFETY_GM, GMSafetyFlags.FLAG_GM_HW_CAM | GMSafetyFlags.FLAG_GM_HW_CAM_LONG)
     self.safety.init_tests()
 
 

--- a/tests/safety/test_honda.py
+++ b/tests/safety/test_honda.py
@@ -2,7 +2,8 @@
 import unittest
 import numpy as np
 
-from panda import Panda
+from opendbc.car.honda.values import HondaSafetyFlags
+from opendbc.safety import Safety
 from panda.tests.libpanda import libpanda_py
 import panda.tests.safety.common as common
 from panda.tests.safety.common import CANPackerPanda, MAX_WRONG_COUNTERS
@@ -310,7 +311,7 @@ class TestHondaNidecSafetyBase(HondaBase):
   def setUp(self):
     self.packer = CANPackerPanda("honda_civic_touring_2016_can_generated")
     self.safety = libpanda_py.libpanda
-    self.safety.set_safety_hooks(Panda.SAFETY_HONDA_NIDEC, 0)
+    self.safety.set_safety_hooks(Safety.SAFETY_HONDA_NIDEC, 0)
     self.safety.init_tests()
 
   def _send_brake_msg(self, brake, aeb_req=0, bus=0):
@@ -400,7 +401,7 @@ class TestHondaNidecPcmAltSafety(TestHondaNidecPcmSafety):
   def setUp(self):
     self.packer = CANPackerPanda("acura_ilx_2016_can_generated")
     self.safety = libpanda_py.libpanda
-    self.safety.set_safety_hooks(Panda.SAFETY_HONDA_NIDEC, Panda.FLAG_HONDA_NIDEC_ALT)
+    self.safety.set_safety_hooks(Safety.SAFETY_HONDA_NIDEC, HondaSafetyFlags.FLAG_HONDA_NIDEC_ALT)
     self.safety.init_tests()
 
   def _acc_state_msg(self, main_on):
@@ -465,7 +466,7 @@ class TestHondaBoschAltBrakeSafetyBase(TestHondaBoschSafetyBase):
   """
   def setUp(self):
     super().setUp()
-    self.safety.set_safety_hooks(Panda.SAFETY_HONDA_BOSCH, Panda.FLAG_HONDA_ALT_BRAKE)
+    self.safety.set_safety_hooks(Safety.SAFETY_HONDA_BOSCH, HondaSafetyFlags.FLAG_HONDA_ALT_BRAKE)
     self.safety.init_tests()
 
   def _user_brake_msg(self, brake):
@@ -487,7 +488,7 @@ class TestHondaBoschSafety(HondaPcmEnableBase, TestHondaBoschSafetyBase):
   """
   def setUp(self):
     super().setUp()
-    self.safety.set_safety_hooks(Panda.SAFETY_HONDA_BOSCH, 0)
+    self.safety.set_safety_hooks(Safety.SAFETY_HONDA_BOSCH, 0)
     self.safety.init_tests()
 
 
@@ -514,7 +515,7 @@ class TestHondaBoschLongSafety(HondaButtonEnableBase, TestHondaBoschSafetyBase):
 
   def setUp(self):
     super().setUp()
-    self.safety.set_safety_hooks(Panda.SAFETY_HONDA_BOSCH, Panda.FLAG_HONDA_BOSCH_LONG)
+    self.safety.set_safety_hooks(Safety.SAFETY_HONDA_BOSCH, HondaSafetyFlags.FLAG_HONDA_BOSCH_LONG)
     self.safety.init_tests()
 
   def _send_gas_brake_msg(self, gas, accel):
@@ -574,7 +575,7 @@ class TestHondaBoschRadarlessSafety(HondaPcmEnableBase, TestHondaBoschRadarlessS
 
   def setUp(self):
     super().setUp()
-    self.safety.set_safety_hooks(Panda.SAFETY_HONDA_BOSCH, Panda.FLAG_HONDA_RADARLESS)
+    self.safety.set_safety_hooks(Safety.SAFETY_HONDA_BOSCH, HondaSafetyFlags.FLAG_HONDA_RADARLESS)
     self.safety.init_tests()
 
 
@@ -585,7 +586,7 @@ class TestHondaBoschRadarlessAltBrakeSafety(HondaPcmEnableBase, TestHondaBoschRa
 
   def setUp(self):
     super().setUp()
-    self.safety.set_safety_hooks(Panda.SAFETY_HONDA_BOSCH, Panda.FLAG_HONDA_RADARLESS | Panda.FLAG_HONDA_ALT_BRAKE)
+    self.safety.set_safety_hooks(Safety.SAFETY_HONDA_BOSCH, HondaSafetyFlags.FLAG_HONDA_RADARLESS | HondaSafetyFlags.FLAG_HONDA_ALT_BRAKE)
     self.safety.init_tests()
 
 
@@ -599,7 +600,7 @@ class TestHondaBoschRadarlessLongSafety(common.LongitudinalAccelSafetyTest, Hond
 
   def setUp(self):
     super().setUp()
-    self.safety.set_safety_hooks(Panda.SAFETY_HONDA_BOSCH, Panda.FLAG_HONDA_RADARLESS | Panda.FLAG_HONDA_BOSCH_LONG)
+    self.safety.set_safety_hooks(Safety.SAFETY_HONDA_BOSCH, HondaSafetyFlags.FLAG_HONDA_RADARLESS | HondaSafetyFlags.FLAG_HONDA_BOSCH_LONG)
     self.safety.init_tests()
 
   def _accel_msg(self, accel):

--- a/tests/safety/test_hyundai.py
+++ b/tests/safety/test_hyundai.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python3
 import random
 import unittest
-from panda import Panda
+
+from opendbc.car.hyundai.values import HyundaiSafetyFlags
+from opendbc.safety import Safety
 from panda.tests.libpanda import libpanda_py
 import panda.tests.safety.common as common
 from panda.tests.safety.common import CANPackerPanda
@@ -72,7 +74,7 @@ class TestHyundaiSafety(HyundaiButtonBase, common.PandaCarSafetyTest, common.Dri
   def setUp(self):
     self.packer = CANPackerPanda("hyundai_kia_generic")
     self.safety = libpanda_py.libpanda
-    self.safety.set_safety_hooks(Panda.SAFETY_HYUNDAI, 0)
+    self.safety.set_safety_hooks(Safety.SAFETY_HYUNDAI, 0)
     self.safety.init_tests()
 
   def _button_msg(self, buttons, main_button=0, bus=0):
@@ -131,7 +133,7 @@ class TestHyundaiSafety(HyundaiButtonBase, common.PandaCarSafetyTest, common.Dri
 
     for hyundai_longitudinal in (True, False):
       with self.subTest("hyundai_longitudinal", hyundai_longitudinal=hyundai_longitudinal):
-        self.safety.set_safety_hooks(Panda.SAFETY_HYUNDAI, 0 if hyundai_longitudinal else Panda.FLAG_HYUNDAI_LONG)
+        self.safety.set_safety_hooks(Safety.SAFETY_HYUNDAI, 0 if hyundai_longitudinal else HyundaiSafetyFlags.FLAG_HYUNDAI_LONG)
         for should_turn_acc_main_on in (True, False):
           with self.subTest("acc_main_on", should_turn_acc_main_on=should_turn_acc_main_on):
             self._rx(self._acc_state_msg(should_turn_acc_main_on))  # Send the ACC state message
@@ -148,7 +150,7 @@ class TestHyundaiSafetyAltLimits(TestHyundaiSafety):
   def setUp(self):
     self.packer = CANPackerPanda("hyundai_kia_generic")
     self.safety = libpanda_py.libpanda
-    self.safety.set_safety_hooks(Panda.SAFETY_HYUNDAI, Panda.FLAG_HYUNDAI_ALT_LIMITS)
+    self.safety.set_safety_hooks(Safety.SAFETY_HYUNDAI, HyundaiSafetyFlags.FLAG_HYUNDAI_ALT_LIMITS)
     self.safety.init_tests()
 
 
@@ -159,7 +161,7 @@ class TestHyundaiSafetyCameraSCC(TestHyundaiSafety):
   def setUp(self):
     self.packer = CANPackerPanda("hyundai_kia_generic")
     self.safety = libpanda_py.libpanda
-    self.safety.set_safety_hooks(Panda.SAFETY_HYUNDAI, Panda.FLAG_HYUNDAI_CAMERA_SCC)
+    self.safety.set_safety_hooks(Safety.SAFETY_HYUNDAI, HyundaiSafetyFlags.FLAG_HYUNDAI_CAMERA_SCC)
     self.safety.init_tests()
 
   def test_pcm_main_cruise_state_availability(self):
@@ -178,7 +180,7 @@ class TestHyundaiLegacySafety(TestHyundaiSafety):
   def setUp(self):
     self.packer = CANPackerPanda("hyundai_kia_generic")
     self.safety = libpanda_py.libpanda
-    self.safety.set_safety_hooks(Panda.SAFETY_HYUNDAI_LEGACY, 0)
+    self.safety.set_safety_hooks(Safety.SAFETY_HYUNDAI_LEGACY, 0)
     self.safety.init_tests()
 
 
@@ -186,7 +188,7 @@ class TestHyundaiLegacySafetyEV(TestHyundaiSafety):
   def setUp(self):
     self.packer = CANPackerPanda("hyundai_kia_generic")
     self.safety = libpanda_py.libpanda
-    self.safety.set_safety_hooks(Panda.SAFETY_HYUNDAI_LEGACY, 1)
+    self.safety.set_safety_hooks(Safety.SAFETY_HYUNDAI_LEGACY, 1)
     self.safety.init_tests()
 
   def _user_gas_msg(self, gas):
@@ -198,7 +200,7 @@ class TestHyundaiLegacySafetyHEV(TestHyundaiSafety):
   def setUp(self):
     self.packer = CANPackerPanda("hyundai_kia_generic")
     self.safety = libpanda_py.libpanda
-    self.safety.set_safety_hooks(Panda.SAFETY_HYUNDAI_LEGACY, 2)
+    self.safety.set_safety_hooks(Safety.SAFETY_HYUNDAI_LEGACY, 2)
     self.safety.init_tests()
 
   def _user_gas_msg(self, gas):
@@ -216,7 +218,7 @@ class TestHyundaiLongitudinalSafety(HyundaiLongitudinalBase, TestHyundaiSafety):
   def setUp(self):
     self.packer = CANPackerPanda("hyundai_kia_generic")
     self.safety = libpanda_py.libpanda
-    self.safety.set_safety_hooks(Panda.SAFETY_HYUNDAI, Panda.FLAG_HYUNDAI_LONG)
+    self.safety.set_safety_hooks(Safety.SAFETY_HYUNDAI, HyundaiSafetyFlags.FLAG_HYUNDAI_LONG)
     self.safety.init_tests()
 
   def _accel_msg(self, accel, aeb_req=False, aeb_decel=0):
@@ -262,7 +264,7 @@ class TestHyundaiLongitudinalESCCSafety(HyundaiLongitudinalBase, TestHyundaiSafe
   def setUp(self):
     self.packer = CANPackerPanda("hyundai_kia_generic")
     self.safety = libpanda_py.libpanda
-    self.safety.set_safety_hooks(Panda.SAFETY_HYUNDAI, Panda.FLAG_HYUNDAI_LONG | Panda.FLAG_HYUNDAI_ESCC)
+    self.safety.set_safety_hooks(Safety.SAFETY_HYUNDAI, HyundaiSafetyFlags.FLAG_HYUNDAI_LONG | HyundaiSafetyFlags.FLAG_HYUNDAI_ESCC)
     self.safety.init_tests()
 
   def _accel_msg(self, accel, aeb_req=False, aeb_decel=0):

--- a/tests/safety/test_hyundai_canfd.py
+++ b/tests/safety/test_hyundai_canfd.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python3
 from parameterized import parameterized_class
 import unittest
-from panda import Panda
+
+from opendbc.car.hyundai.values import HyundaiSafetyFlags
+from opendbc.safety import Safety
 from panda.tests.libpanda import libpanda_py
 import panda.tests.safety.common as common
 from panda.tests.safety.common import CANPackerPanda
@@ -112,19 +114,23 @@ class TestHyundaiCanfdHDA1Base(TestHyundaiCanfdBase):
   def setUp(self):
     self.packer = CANPackerPanda("hyundai_canfd")
     self.safety = libpanda_py.libpanda
-    self.safety.set_safety_hooks(Panda.SAFETY_HYUNDAI_CANFD, self.SAFETY_PARAM)
+    self.safety.set_safety_hooks(Safety.SAFETY_HYUNDAI_CANFD, self.SAFETY_PARAM)
     self.safety.init_tests()
 
 
 @parameterized_class([
   # Radar SCC, test with long flag to ensure flag is not respected until it is supported
-  {"GAS_MSG": ("ACCELERATOR_BRAKE_ALT", "ACCELERATOR_PEDAL_PRESSED"), "SCC_BUS": 0, "SAFETY_PARAM": Panda.FLAG_HYUNDAI_LONG},
-  {"GAS_MSG": ("ACCELERATOR", "ACCELERATOR_PEDAL"), "SCC_BUS": 0, "SAFETY_PARAM": Panda.FLAG_HYUNDAI_EV_GAS | Panda.FLAG_HYUNDAI_LONG},
-  {"GAS_MSG": ("ACCELERATOR_ALT", "ACCELERATOR_PEDAL"), "SCC_BUS": 0, "SAFETY_PARAM": Panda.FLAG_HYUNDAI_HYBRID_GAS | Panda.FLAG_HYUNDAI_LONG},
+  {"GAS_MSG": ("ACCELERATOR_BRAKE_ALT", "ACCELERATOR_PEDAL_PRESSED"), "SCC_BUS": 0, "SAFETY_PARAM": HyundaiSafetyFlags.FLAG_HYUNDAI_LONG},
+  {"GAS_MSG": ("ACCELERATOR", "ACCELERATOR_PEDAL"), "SCC_BUS": 0, "SAFETY_PARAM": HyundaiSafetyFlags.FLAG_HYUNDAI_EV_GAS |
+                                                                                  HyundaiSafetyFlags.FLAG_HYUNDAI_LONG},
+  {"GAS_MSG": ("ACCELERATOR_ALT", "ACCELERATOR_PEDAL"), "SCC_BUS": 0, "SAFETY_PARAM": HyundaiSafetyFlags.FLAG_HYUNDAI_HYBRID_GAS |
+                                                                                      HyundaiSafetyFlags.FLAG_HYUNDAI_LONG},
   # Camera SCC
-  {"GAS_MSG": ("ACCELERATOR_BRAKE_ALT", "ACCELERATOR_PEDAL_PRESSED"), "SCC_BUS": 2, "SAFETY_PARAM": Panda.FLAG_HYUNDAI_CAMERA_SCC},
-  {"GAS_MSG": ("ACCELERATOR", "ACCELERATOR_PEDAL"), "SCC_BUS": 2, "SAFETY_PARAM": Panda.FLAG_HYUNDAI_EV_GAS | Panda.FLAG_HYUNDAI_CAMERA_SCC},
-  {"GAS_MSG": ("ACCELERATOR_ALT", "ACCELERATOR_PEDAL"), "SCC_BUS": 2, "SAFETY_PARAM": Panda.FLAG_HYUNDAI_HYBRID_GAS | Panda.FLAG_HYUNDAI_CAMERA_SCC},
+  {"GAS_MSG": ("ACCELERATOR_BRAKE_ALT", "ACCELERATOR_PEDAL_PRESSED"), "SCC_BUS": 2, "SAFETY_PARAM": HyundaiSafetyFlags.FLAG_HYUNDAI_CAMERA_SCC},
+  {"GAS_MSG": ("ACCELERATOR", "ACCELERATOR_PEDAL"), "SCC_BUS": 2, "SAFETY_PARAM": HyundaiSafetyFlags.FLAG_HYUNDAI_EV_GAS |
+                                                                                  HyundaiSafetyFlags.FLAG_HYUNDAI_CAMERA_SCC},
+  {"GAS_MSG": ("ACCELERATOR_ALT", "ACCELERATOR_PEDAL"), "SCC_BUS": 2, "SAFETY_PARAM": HyundaiSafetyFlags.FLAG_HYUNDAI_HYBRID_GAS |
+                                                                                      HyundaiSafetyFlags.FLAG_HYUNDAI_CAMERA_SCC},
 ])
 class TestHyundaiCanfdHDA1(TestHyundaiCanfdHDA1Base):
   pass
@@ -132,13 +138,17 @@ class TestHyundaiCanfdHDA1(TestHyundaiCanfdHDA1Base):
 
 @parameterized_class([
   # Radar SCC, test with long flag to ensure flag is not respected until it is supported
-  {"GAS_MSG": ("ACCELERATOR_BRAKE_ALT", "ACCELERATOR_PEDAL_PRESSED"), "SCC_BUS": 0, "SAFETY_PARAM": Panda.FLAG_HYUNDAI_LONG},
-  {"GAS_MSG": ("ACCELERATOR", "ACCELERATOR_PEDAL"), "SCC_BUS": 0, "SAFETY_PARAM": Panda.FLAG_HYUNDAI_EV_GAS | Panda.FLAG_HYUNDAI_LONG},
-  {"GAS_MSG": ("ACCELERATOR_ALT", "ACCELERATOR_PEDAL"), "SCC_BUS": 0, "SAFETY_PARAM": Panda.FLAG_HYUNDAI_HYBRID_GAS | Panda.FLAG_HYUNDAI_LONG},
+  {"GAS_MSG": ("ACCELERATOR_BRAKE_ALT", "ACCELERATOR_PEDAL_PRESSED"), "SCC_BUS": 0, "SAFETY_PARAM": HyundaiSafetyFlags.FLAG_HYUNDAI_LONG},
+  {"GAS_MSG": ("ACCELERATOR", "ACCELERATOR_PEDAL"), "SCC_BUS": 0, "SAFETY_PARAM": HyundaiSafetyFlags.FLAG_HYUNDAI_EV_GAS |
+                                                                                  HyundaiSafetyFlags.FLAG_HYUNDAI_LONG},
+  {"GAS_MSG": ("ACCELERATOR_ALT", "ACCELERATOR_PEDAL"), "SCC_BUS": 0, "SAFETY_PARAM": HyundaiSafetyFlags.FLAG_HYUNDAI_HYBRID_GAS |
+                                                                                      HyundaiSafetyFlags.FLAG_HYUNDAI_LONG},
   # Camera SCC
-  {"GAS_MSG": ("ACCELERATOR_BRAKE_ALT", "ACCELERATOR_PEDAL_PRESSED"), "SCC_BUS": 2, "SAFETY_PARAM": Panda.FLAG_HYUNDAI_CAMERA_SCC},
-  {"GAS_MSG": ("ACCELERATOR", "ACCELERATOR_PEDAL"), "SCC_BUS": 2, "SAFETY_PARAM": Panda.FLAG_HYUNDAI_EV_GAS | Panda.FLAG_HYUNDAI_CAMERA_SCC},
-  {"GAS_MSG": ("ACCELERATOR_ALT", "ACCELERATOR_PEDAL"), "SCC_BUS": 2, "SAFETY_PARAM": Panda.FLAG_HYUNDAI_HYBRID_GAS | Panda.FLAG_HYUNDAI_CAMERA_SCC},
+  {"GAS_MSG": ("ACCELERATOR_BRAKE_ALT", "ACCELERATOR_PEDAL_PRESSED"), "SCC_BUS": 2, "SAFETY_PARAM": HyundaiSafetyFlags.FLAG_HYUNDAI_CAMERA_SCC},
+  {"GAS_MSG": ("ACCELERATOR", "ACCELERATOR_PEDAL"), "SCC_BUS": 2, "SAFETY_PARAM": HyundaiSafetyFlags.FLAG_HYUNDAI_EV_GAS |
+                                                                                  HyundaiSafetyFlags.FLAG_HYUNDAI_CAMERA_SCC},
+  {"GAS_MSG": ("ACCELERATOR_ALT", "ACCELERATOR_PEDAL"), "SCC_BUS": 2, "SAFETY_PARAM": HyundaiSafetyFlags.FLAG_HYUNDAI_HYBRID_GAS |
+                                                                                      HyundaiSafetyFlags.FLAG_HYUNDAI_CAMERA_SCC},
 ])
 class TestHyundaiCanfdHDA1AltButtons(TestHyundaiCanfdHDA1Base):
 
@@ -147,7 +157,7 @@ class TestHyundaiCanfdHDA1AltButtons(TestHyundaiCanfdHDA1Base):
   def setUp(self):
     self.packer = CANPackerPanda("hyundai_canfd")
     self.safety = libpanda_py.libpanda
-    self.safety.set_safety_hooks(Panda.SAFETY_HYUNDAI_CANFD, Panda.FLAG_HYUNDAI_CANFD_ALT_BUTTONS | self.SAFETY_PARAM)
+    self.safety.set_safety_hooks(Safety.SAFETY_HYUNDAI_CANFD, HyundaiSafetyFlags.FLAG_HYUNDAI_CANFD_ALT_BUTTONS | self.SAFETY_PARAM)
     self.safety.init_tests()
 
   def _button_msg(self, buttons, main_button=0, bus=1):
@@ -186,7 +196,7 @@ class TestHyundaiCanfdHDA2EV(TestHyundaiCanfdBase):
   def setUp(self):
     self.packer = CANPackerPanda("hyundai_canfd")
     self.safety = libpanda_py.libpanda
-    self.safety.set_safety_hooks(Panda.SAFETY_HYUNDAI_CANFD, Panda.FLAG_HYUNDAI_CANFD_HDA2 | Panda.FLAG_HYUNDAI_EV_GAS)
+    self.safety.set_safety_hooks(Safety.SAFETY_HYUNDAI_CANFD, HyundaiSafetyFlags.FLAG_HYUNDAI_CANFD_HDA2 | HyundaiSafetyFlags.FLAG_HYUNDAI_EV_GAS)
     self.safety.init_tests()
 
 
@@ -206,8 +216,8 @@ class TestHyundaiCanfdHDA2EVAltSteering(TestHyundaiCanfdBase):
   def setUp(self):
     self.packer = CANPackerPanda("hyundai_canfd")
     self.safety = libpanda_py.libpanda
-    self.safety.set_safety_hooks(Panda.SAFETY_HYUNDAI_CANFD, Panda.FLAG_HYUNDAI_CANFD_HDA2 | Panda.FLAG_HYUNDAI_EV_GAS |
-                                 Panda.FLAG_HYUNDAI_CANFD_HDA2_ALT_STEERING)
+    self.safety.set_safety_hooks(Safety.SAFETY_HYUNDAI_CANFD, HyundaiSafetyFlags.FLAG_HYUNDAI_CANFD_HDA2 | HyundaiSafetyFlags.FLAG_HYUNDAI_EV_GAS |
+                                 HyundaiSafetyFlags.FLAG_HYUNDAI_CANFD_HDA2_ALT_STEERING)
     self.safety.init_tests()
 
 
@@ -228,7 +238,8 @@ class TestHyundaiCanfdHDA2LongEV(HyundaiLongitudinalBase, TestHyundaiCanfdHDA2EV
   def setUp(self):
     self.packer = CANPackerPanda("hyundai_canfd")
     self.safety = libpanda_py.libpanda
-    self.safety.set_safety_hooks(Panda.SAFETY_HYUNDAI_CANFD, Panda.FLAG_HYUNDAI_CANFD_HDA2 | Panda.FLAG_HYUNDAI_LONG | Panda.FLAG_HYUNDAI_EV_GAS)
+    self.safety.set_safety_hooks(Safety.SAFETY_HYUNDAI_CANFD, HyundaiSafetyFlags.FLAG_HYUNDAI_CANFD_HDA2 |
+                                 HyundaiSafetyFlags.FLAG_HYUNDAI_LONG | HyundaiSafetyFlags.FLAG_HYUNDAI_EV_GAS)
     self.safety.init_tests()
 
   def _accel_msg(self, accel, aeb_req=False, aeb_decel=0):
@@ -246,9 +257,9 @@ class TestHyundaiCanfdHDA2LongEV(HyundaiLongitudinalBase, TestHyundaiCanfdHDA2EV
 # Tests HDA1 longitudinal for ICE, hybrid, EV
 @parameterized_class([
   # Camera SCC is the only supported configuration for HDA1 longitudinal, TODO: allow radar SCC
-  {"GAS_MSG": ("ACCELERATOR_BRAKE_ALT", "ACCELERATOR_PEDAL_PRESSED"), "SAFETY_PARAM": Panda.FLAG_HYUNDAI_LONG},
-  {"GAS_MSG": ("ACCELERATOR", "ACCELERATOR_PEDAL"), "SAFETY_PARAM": Panda.FLAG_HYUNDAI_LONG | Panda.FLAG_HYUNDAI_EV_GAS},
-  {"GAS_MSG": ("ACCELERATOR_ALT", "ACCELERATOR_PEDAL"), "SAFETY_PARAM": Panda.FLAG_HYUNDAI_LONG | Panda.FLAG_HYUNDAI_HYBRID_GAS},
+  {"GAS_MSG": ("ACCELERATOR_BRAKE_ALT", "ACCELERATOR_PEDAL_PRESSED"), "SAFETY_PARAM": HyundaiSafetyFlags.FLAG_HYUNDAI_LONG},
+  {"GAS_MSG": ("ACCELERATOR", "ACCELERATOR_PEDAL"), "SAFETY_PARAM": HyundaiSafetyFlags.FLAG_HYUNDAI_LONG | HyundaiSafetyFlags.FLAG_HYUNDAI_EV_GAS},
+  {"GAS_MSG": ("ACCELERATOR_ALT", "ACCELERATOR_PEDAL"), "SAFETY_PARAM": HyundaiSafetyFlags.FLAG_HYUNDAI_LONG | HyundaiSafetyFlags.FLAG_HYUNDAI_HYBRID_GAS},
 ])
 class TestHyundaiCanfdHDA1Long(HyundaiLongitudinalBase, TestHyundaiCanfdHDA1Base):
 
@@ -272,7 +283,7 @@ class TestHyundaiCanfdHDA1Long(HyundaiLongitudinalBase, TestHyundaiCanfdHDA1Base
   def setUp(self):
     self.packer = CANPackerPanda("hyundai_canfd")
     self.safety = libpanda_py.libpanda
-    self.safety.set_safety_hooks(Panda.SAFETY_HYUNDAI_CANFD, Panda.FLAG_HYUNDAI_CAMERA_SCC | self.SAFETY_PARAM)
+    self.safety.set_safety_hooks(Safety.SAFETY_HYUNDAI_CANFD, HyundaiSafetyFlags.FLAG_HYUNDAI_CAMERA_SCC | self.SAFETY_PARAM)
     self.safety.init_tests()
 
   def _accel_msg(self, accel, aeb_req=False, aeb_decel=0):

--- a/tests/safety/test_mazda.py
+++ b/tests/safety/test_mazda.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 import unittest
-from panda import Panda
+from opendbc.safety import Safety
 from panda.tests.libpanda import libpanda_py
 import panda.tests.safety.common as common
 from panda.tests.safety.common import CANPackerPanda
@@ -30,7 +30,7 @@ class TestMazdaSafety(common.PandaCarSafetyTest, common.DriverTorqueSteeringSafe
   def setUp(self):
     self.packer = CANPackerPanda("mazda_2017")
     self.safety = libpanda_py.libpanda
-    self.safety.set_safety_hooks(Panda.SAFETY_MAZDA, 0)
+    self.safety.set_safety_hooks(Safety.SAFETY_MAZDA, 0)
     self.safety.init_tests()
 
   def _torque_meas_msg(self, torque):

--- a/tests/safety/test_nissan.py
+++ b/tests/safety/test_nissan.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 import unittest
-from panda import Panda
+
+from opendbc.car.nissan.values import NissanSafetyFlags
+from opendbc.safety import Safety
 from panda.tests.libpanda import libpanda_py
 import panda.tests.safety.common as common
 from panda.tests.safety.common import CANPackerPanda
@@ -29,7 +31,7 @@ class TestNissanSafety(common.PandaCarSafetyTest, common.AngleSteeringSafetyTest
   def setUp(self):
     self.packer = CANPackerPanda("nissan_x_trail_2017_generated")
     self.safety = libpanda_py.libpanda
-    self.safety.set_safety_hooks(Panda.SAFETY_NISSAN, 0)
+    self.safety.set_safety_hooks(Safety.SAFETY_NISSAN, 0)
     self.safety.init_tests()
 
   def _angle_cmd_msg(self, angle: float, enabled: bool):
@@ -94,7 +96,7 @@ class TestNissanSafetyAltEpsBus(TestNissanSafety):
   def setUp(self):
     self.packer = CANPackerPanda("nissan_x_trail_2017_generated")
     self.safety = libpanda_py.libpanda
-    self.safety.set_safety_hooks(Panda.SAFETY_NISSAN, Panda.FLAG_NISSAN_ALT_EPS_BUS)
+    self.safety.set_safety_hooks(Safety.SAFETY_NISSAN, NissanSafetyFlags.FLAG_NISSAN_ALT_EPS_BUS)
     self.safety.init_tests()
 
   def _acc_state_msg(self, main_on):
@@ -107,7 +109,7 @@ class TestNissanLeafSafety(TestNissanSafety):
   def setUp(self):
     self.packer = CANPackerPanda("nissan_leaf_2018_generated")
     self.safety = libpanda_py.libpanda
-    self.safety.set_safety_hooks(Panda.SAFETY_NISSAN, Panda.FLAG_NISSAN_LEAF)
+    self.safety.set_safety_hooks(Safety.SAFETY_NISSAN, NissanSafetyFlags.FLAG_NISSAN_LEAF)
     self.safety.init_tests()
 
   def _user_brake_msg(self, brake):

--- a/tests/safety/test_subaru.py
+++ b/tests/safety/test_subaru.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python3
 import enum
 import unittest
-from panda import Panda
+
+from opendbc.car.subaru.values import SubaruSafetyFlags
+from opendbc.safety import Safety
 from panda.tests.libpanda import libpanda_py
 import panda.tests.safety.common as common
 from panda.tests.safety.common import CANPackerPanda
@@ -75,7 +77,7 @@ class TestSubaruSafetyBase(common.PandaCarSafetyTest):
   def setUp(self):
     self.packer = CANPackerPanda("subaru_global_2017_generated")
     self.safety = libpanda_py.libpanda
-    self.safety.set_safety_hooks(Panda.SAFETY_SUBARU, self.FLAGS)
+    self.safety.set_safety_hooks(Safety.SAFETY_SUBARU, self.FLAGS)
     self.safety.init_tests()
 
   def _set_prev_torque(self, t):
@@ -198,17 +200,17 @@ class TestSubaruGen2TorqueSafetyBase(TestSubaruTorqueSafetyBase):
 
 
 class TestSubaruGen2TorqueStockLongitudinalSafety(TestSubaruStockLongitudinalSafetyBase, TestSubaruGen2TorqueSafetyBase):
-  FLAGS = Panda.FLAG_SUBARU_GEN2
+  FLAGS = SubaruSafetyFlags.FLAG_SUBARU_GEN2
   TX_MSGS = lkas_tx_msgs(SUBARU_ALT_BUS)
 
 
 class TestSubaruGen1LongitudinalSafety(TestSubaruLongitudinalSafetyBase, TestSubaruTorqueSafetyBase):
-  FLAGS = Panda.FLAG_SUBARU_LONG
+  FLAGS = SubaruSafetyFlags.FLAG_SUBARU_LONG
   TX_MSGS = lkas_tx_msgs(SUBARU_MAIN_BUS) + long_tx_msgs(SUBARU_MAIN_BUS)
 
 
 class TestSubaruGen2LongitudinalSafety(TestSubaruLongitudinalSafetyBase, TestSubaruGen2TorqueSafetyBase):
-  FLAGS = Panda.FLAG_SUBARU_LONG | Panda.FLAG_SUBARU_GEN2
+  FLAGS = SubaruSafetyFlags.FLAG_SUBARU_LONG | SubaruSafetyFlags.FLAG_SUBARU_GEN2
   TX_MSGS = lkas_tx_msgs(SUBARU_ALT_BUS) + long_tx_msgs(SUBARU_ALT_BUS) + gen2_long_additional_tx_msgs()
 
   def _rdbi_msg(self, did: int):

--- a/tests/safety/test_subaru_preglobal.py
+++ b/tests/safety/test_subaru_preglobal.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 import unittest
-from panda import Panda
+
+from opendbc.car.subaru.values import SubaruSafetyFlags
+from opendbc.safety import Safety
 from panda.tests.libpanda import libpanda_py
 import panda.tests.safety.common as common
 from panda.tests.safety.common import CANPackerPanda
@@ -28,7 +30,7 @@ class TestSubaruPreglobalSafety(common.PandaCarSafetyTest, common.DriverTorqueSt
   def setUp(self):
     self.packer = CANPackerPanda(self.DBC)
     self.safety = libpanda_py.libpanda
-    self.safety.set_safety_hooks(Panda.SAFETY_SUBARU_PREGLOBAL, self.FLAGS)
+    self.safety.set_safety_hooks(Safety.SAFETY_SUBARU_PREGLOBAL, self.FLAGS)
     self.safety.init_tests()
 
   def _set_prev_torque(self, t):
@@ -62,7 +64,7 @@ class TestSubaruPreglobalSafety(common.PandaCarSafetyTest, common.DriverTorqueSt
 
 
 class TestSubaruPreglobalReversedDriverTorqueSafety(TestSubaruPreglobalSafety):
-  FLAGS = Panda.FLAG_SUBARU_PREGLOBAL_REVERSED_DRIVER_TORQUE
+  FLAGS = SubaruSafetyFlags.FLAG_SUBARU_PREGLOBAL_REVERSED_DRIVER_TORQUE
   DBC = "subaru_outback_2019_generated"
 
 

--- a/tests/safety/test_tesla.py
+++ b/tests/safety/test_tesla.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python3
 import unittest
 import numpy as np
-from panda import Panda
+
+from opendbc.car.tesla.values import TeslaSafetyFlags
+from opendbc.safety import Safety
 import panda.tests.safety.common as common
 from panda.tests.libpanda import libpanda_py
 from panda.tests.safety.common import CANPackerPanda
@@ -77,7 +79,7 @@ class TestTeslaSteeringSafety(TestTeslaSafety, common.AngleSteeringSafetyTest):
   def setUp(self):
     self.packer = CANPackerPanda("tesla_can")
     self.safety = libpanda_py.libpanda
-    self.safety.set_safety_hooks(Panda.SAFETY_TESLA, 0)
+    self.safety.set_safety_hooks(Safety.SAFETY_TESLA, 0)
     self.safety.init_tests()
 
   def _angle_cmd_msg(self, angle: float, enabled: bool):
@@ -112,7 +114,7 @@ class TestTeslaRavenSteeringSafety(TestTeslaSteeringSafety):
   def setUp(self):
     self.packer = CANPackerPanda("tesla_can")
     self.safety = libpanda_py.libpanda
-    self.safety.set_safety_hooks(Panda.SAFETY_TESLA, Panda.FLAG_TESLA_RAVEN)
+    self.safety.set_safety_hooks(Safety.SAFETY_TESLA, TeslaSafetyFlags.FLAG_TESLA_RAVEN)
     self.safety.init_tests()
 
   def _angle_meas_msg(self, angle: float):
@@ -165,7 +167,7 @@ class TestTeslaChassisLongitudinalSafety(TestTeslaLongitudinalSafety):
   def setUp(self):
     self.packer = CANPackerPanda("tesla_can")
     self.safety = libpanda_py.libpanda
-    self.safety.set_safety_hooks(Panda.SAFETY_TESLA, Panda.FLAG_TESLA_LONG_CONTROL)
+    self.safety.set_safety_hooks(Safety.SAFETY_TESLA, TeslaSafetyFlags.FLAG_TESLA_LONG_CONTROL)
     self.safety.init_tests()
 
 
@@ -177,7 +179,7 @@ class TestTeslaPTLongitudinalSafety(TestTeslaLongitudinalSafety):
   def setUp(self):
     self.packer = CANPackerPanda("tesla_powertrain")
     self.safety = libpanda_py.libpanda
-    self.safety.set_safety_hooks(Panda.SAFETY_TESLA, Panda.FLAG_TESLA_LONG_CONTROL | Panda.FLAG_TESLA_POWERTRAIN)
+    self.safety.set_safety_hooks(Safety.SAFETY_TESLA, TeslaSafetyFlags.FLAG_TESLA_LONG_CONTROL | TeslaSafetyFlags.FLAG_TESLA_POWERTRAIN)
     self.safety.init_tests()
 
 

--- a/tests/safety/test_toyota.py
+++ b/tests/safety/test_toyota.py
@@ -4,7 +4,8 @@ import random
 import unittest
 import itertools
 
-from panda import Panda
+from opendbc.car.toyota.values import ToyotaSafetyFlags
+from opendbc.safety import Safety
 from panda.tests.libpanda import libpanda_py
 import panda.tests.safety.common as common
 from panda.tests.safety.common import CANPackerPanda
@@ -145,7 +146,7 @@ class TestToyotaSafetyTorque(TestToyotaSafetyBase, common.MotorTorqueSteeringSaf
   def setUp(self):
     self.packer = CANPackerPanda("toyota_nodsu_pt_generated")
     self.safety = libpanda_py.libpanda
-    self.safety.set_safety_hooks(Panda.SAFETY_TOYOTA, self.EPS_SCALE)
+    self.safety.set_safety_hooks(Safety.SAFETY_TOYOTA, self.EPS_SCALE)
     self.safety.init_tests()
 
 
@@ -165,7 +166,7 @@ class TestToyotaSafetyAngle(TestToyotaSafetyBase, common.AngleSteeringSafetyTest
   def setUp(self):
     self.packer = CANPackerPanda("toyota_nodsu_pt_generated")
     self.safety = libpanda_py.libpanda
-    self.safety.set_safety_hooks(Panda.SAFETY_TOYOTA, self.EPS_SCALE | Panda.FLAG_TOYOTA_LTA)
+    self.safety.set_safety_hooks(Safety.SAFETY_TOYOTA, self.EPS_SCALE | ToyotaSafetyFlags.FLAG_TOYOTA_LTA)
     self.safety.init_tests()
 
   # Only allow LKA msgs with no actuation
@@ -267,7 +268,7 @@ class TestToyotaAltBrakeSafety(TestToyotaSafetyTorque):
   def setUp(self):
     self.packer = CANPackerPanda("toyota_new_mc_pt_generated")
     self.safety = libpanda_py.libpanda
-    self.safety.set_safety_hooks(Panda.SAFETY_TOYOTA, self.EPS_SCALE | Panda.FLAG_TOYOTA_ALT_BRAKE)
+    self.safety.set_safety_hooks(Safety.SAFETY_TOYOTA, self.EPS_SCALE | ToyotaSafetyFlags.FLAG_TOYOTA_ALT_BRAKE)
     self.safety.init_tests()
 
   def _user_brake_msg(self, brake):
@@ -312,7 +313,7 @@ class TestToyotaStockLongitudinalTorque(TestToyotaStockLongitudinalBase, TestToy
   def setUp(self):
     self.packer = CANPackerPanda("toyota_nodsu_pt_generated")
     self.safety = libpanda_py.libpanda
-    self.safety.set_safety_hooks(Panda.SAFETY_TOYOTA, self.EPS_SCALE | Panda.FLAG_TOYOTA_STOCK_LONGITUDINAL)
+    self.safety.set_safety_hooks(Safety.SAFETY_TOYOTA, self.EPS_SCALE | ToyotaSafetyFlags.FLAG_TOYOTA_STOCK_LONGITUDINAL)
     self.safety.init_tests()
 
 
@@ -321,7 +322,7 @@ class TestToyotaStockLongitudinalAngle(TestToyotaStockLongitudinalBase, TestToyo
   def setUp(self):
     self.packer = CANPackerPanda("toyota_nodsu_pt_generated")
     self.safety = libpanda_py.libpanda
-    self.safety.set_safety_hooks(Panda.SAFETY_TOYOTA, self.EPS_SCALE | Panda.FLAG_TOYOTA_STOCK_LONGITUDINAL | Panda.FLAG_TOYOTA_LTA)
+    self.safety.set_safety_hooks(Safety.SAFETY_TOYOTA, self.EPS_SCALE | ToyotaSafetyFlags.FLAG_TOYOTA_STOCK_LONGITUDINAL | ToyotaSafetyFlags.FLAG_TOYOTA_LTA)
     self.safety.init_tests()
 
 
@@ -334,7 +335,7 @@ class TestToyotaSecOcSafety(TestToyotaStockLongitudinalBase):
   def setUp(self):
     self.packer = CANPackerPanda("toyota_secoc_pt_generated")
     self.safety = libpanda_py.libpanda
-    self.safety.set_safety_hooks(Panda.SAFETY_TOYOTA, self.EPS_SCALE | Panda.FLAG_TOYOTA_STOCK_LONGITUDINAL | Panda.FLAG_TOYOTA_SECOC)
+    self.safety.set_safety_hooks(Safety.SAFETY_TOYOTA, self.EPS_SCALE | ToyotaSafetyFlags.FLAG_TOYOTA_STOCK_LONGITUDINAL | ToyotaSafetyFlags.FLAG_TOYOTA_SECOC)
     self.safety.init_tests()
 
   # This platform also has alternate brake and PCM messages, but same naming in the DBC, so same packers work

--- a/tests/safety/test_volkswagen_mqb.py
+++ b/tests/safety/test_volkswagen_mqb.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python3
 import unittest
 import numpy as np
-from panda import Panda
+from opendbc.safety import Safety
 from panda.tests.libpanda import libpanda_py
 import panda.tests.safety.common as common
 from panda.tests.safety.common import CANPackerPanda
+from opendbc.car.volkswagen.values import VolkswagenSafetyFlags
 
 MAX_ACCEL = 2.0
 MIN_ACCEL = -3.5
@@ -143,7 +144,7 @@ class TestVolkswagenMqbStockSafety(TestVolkswagenMqbSafety):
   def setUp(self):
     self.packer = CANPackerPanda("vw_mqb_2010")
     self.safety = libpanda_py.libpanda
-    self.safety.set_safety_hooks(Panda.SAFETY_VOLKSWAGEN_MQB, 0)
+    self.safety.set_safety_hooks(Safety.SAFETY_VOLKSWAGEN_MQB, 0)
     self.safety.init_tests()
 
   def test_spam_cancel_safety_check(self):
@@ -165,7 +166,7 @@ class TestVolkswagenMqbLongSafety(TestVolkswagenMqbSafety):
   def setUp(self):
     self.packer = CANPackerPanda("vw_mqb_2010")
     self.safety = libpanda_py.libpanda
-    self.safety.set_safety_hooks(Panda.SAFETY_VOLKSWAGEN_MQB, Panda.FLAG_VOLKSWAGEN_LONG_CONTROL)
+    self.safety.set_safety_hooks(Safety.SAFETY_VOLKSWAGEN_MQB, VolkswagenSafetyFlags.FLAG_VOLKSWAGEN_LONG_CONTROL)
     self.safety.init_tests()
 
   # stock cruise controls are entirely bypassed under openpilot longitudinal control

--- a/tests/safety/test_volkswagen_pq.py
+++ b/tests/safety/test_volkswagen_pq.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 import unittest
-from panda import Panda
+
+from opendbc.car.volkswagen.values import VolkswagenSafetyFlags
+from opendbc.safety import Safety
 from panda.tests.libpanda import libpanda_py
 import panda.tests.safety.common as common
 from panda.tests.safety.common import CANPackerPanda
@@ -125,7 +127,7 @@ class TestVolkswagenPqStockSafety(TestVolkswagenPqSafety):
   def setUp(self):
     self.packer = CANPackerPanda("vw_golf_mk4")
     self.safety = libpanda_py.libpanda
-    self.safety.set_safety_hooks(Panda.SAFETY_VOLKSWAGEN_PQ, 0)
+    self.safety.set_safety_hooks(Safety.SAFETY_VOLKSWAGEN_PQ, 0)
     self.safety.init_tests()
 
   def test_spam_cancel_safety_check(self):
@@ -147,7 +149,7 @@ class TestVolkswagenPqLongSafety(TestVolkswagenPqSafety, common.LongitudinalAcce
   def setUp(self):
     self.packer = CANPackerPanda("vw_golf_mk4")
     self.safety = libpanda_py.libpanda
-    self.safety.set_safety_hooks(Panda.SAFETY_VOLKSWAGEN_PQ, Panda.FLAG_VOLKSWAGEN_LONG_CONTROL)
+    self.safety.set_safety_hooks(Safety.SAFETY_VOLKSWAGEN_PQ, VolkswagenSafetyFlags.FLAG_VOLKSWAGEN_LONG_CONTROL)
     self.safety.init_tests()
 
   # stock cruise controls are entirely bypassed under openpilot longitudinal control

--- a/tests/safety_replay/helpers.py
+++ b/tests/safety_replay/helpers.py
@@ -1,5 +1,6 @@
+from opendbc.car.toyota.values import ToyotaSafetyFlags
+from opendbc.safety import Safety
 import panda.tests.libpanda.libpanda_py as libpanda_py
-from panda import Panda
 
 def to_signed(d, bits):
   ret = d
@@ -9,49 +10,49 @@ def to_signed(d, bits):
 
 def is_steering_msg(mode, param, addr):
   ret = False
-  if mode in (Panda.SAFETY_HONDA_NIDEC, Panda.SAFETY_HONDA_BOSCH):
+  if mode in (Safety.SAFETY_HONDA_NIDEC, Safety.SAFETY_HONDA_BOSCH):
     ret = (addr == 0xE4) or (addr == 0x194) or (addr == 0x33D) or (addr == 0x33DA) or (addr == 0x33DB)
-  elif mode == Panda.SAFETY_TOYOTA:
-    ret = addr == (0x191 if param & Panda.FLAG_TOYOTA_LTA else 0x2E4)
-  elif mode == Panda.SAFETY_GM:
+  elif mode == Safety.SAFETY_TOYOTA:
+    ret = addr == (0x191 if param & ToyotaSafetyFlags.FLAG_TOYOTA_LTA else 0x2E4)
+  elif mode == Safety.SAFETY_GM:
     ret = addr == 384
-  elif mode == Panda.SAFETY_HYUNDAI:
+  elif mode == Safety.SAFETY_HYUNDAI:
     ret = addr == 832
-  elif mode == Panda.SAFETY_CHRYSLER:
+  elif mode == Safety.SAFETY_CHRYSLER:
     ret = addr == 0x292
-  elif mode == Panda.SAFETY_SUBARU:
+  elif mode == Safety.SAFETY_SUBARU:
     ret = addr == 0x122
-  elif mode == Panda.SAFETY_FORD:
+  elif mode == Safety.SAFETY_FORD:
     ret = addr == 0x3d3
-  elif mode == Panda.SAFETY_NISSAN:
+  elif mode == Safety.SAFETY_NISSAN:
     ret = addr == 0x169
   return ret
 
 def get_steer_value(mode, param, to_send):
   torque, angle = 0, 0
-  if mode in (Panda.SAFETY_HONDA_NIDEC, Panda.SAFETY_HONDA_BOSCH):
+  if mode in (Safety.SAFETY_HONDA_NIDEC, Safety.SAFETY_HONDA_BOSCH):
     torque = (to_send.data[0] << 8) | to_send.data[1]
     torque = to_signed(torque, 16)
-  elif mode == Panda.SAFETY_TOYOTA:
-    if param & Panda.FLAG_TOYOTA_LTA:
+  elif mode == Safety.SAFETY_TOYOTA:
+    if param & ToyotaSafetyFlags.FLAG_TOYOTA_LTA:
       angle = (to_send.data[1] << 8) | to_send.data[2]
       angle = to_signed(angle, 16)
     else:
       torque = (to_send.data[1] << 8) | (to_send.data[2])
       torque = to_signed(torque, 16)
-  elif mode == Panda.SAFETY_GM:
+  elif mode == Safety.SAFETY_GM:
     torque = ((to_send.data[0] & 0x7) << 8) | to_send.data[1]
     torque = to_signed(torque, 11)
-  elif mode == Panda.SAFETY_HYUNDAI:
+  elif mode == Safety.SAFETY_HYUNDAI:
     torque = (((to_send.data[3] & 0x7) << 8) | to_send.data[2]) - 1024
-  elif mode == Panda.SAFETY_CHRYSLER:
+  elif mode == Safety.SAFETY_CHRYSLER:
     torque = (((to_send.data[0] & 0x7) << 8) | to_send.data[1]) - 1024
-  elif mode == Panda.SAFETY_SUBARU:
+  elif mode == Safety.SAFETY_SUBARU:
     torque = ((to_send.data[3] & 0x1F) << 8) | to_send.data[2]
     torque = -to_signed(torque, 13)
-  elif mode == Panda.SAFETY_FORD:
+  elif mode == Safety.SAFETY_FORD:
     angle = ((to_send.data[0] << 3) | (to_send.data[1] >> 5)) - 1000
-  elif mode == Panda.SAFETY_NISSAN:
+  elif mode == Safety.SAFETY_NISSAN:
     angle = (to_send.data[0] << 10) | (to_send.data[1] << 2) | (to_send.data[2] >> 6)
     angle = -angle + (1310 * 100)
   return torque, angle

--- a/tests/safety_replay/replay_drive.py
+++ b/tests/safety_replay/replay_drive.py
@@ -3,7 +3,7 @@ import argparse
 import os
 from collections import Counter, defaultdict
 
-from panda.python import ALTERNATIVE_EXPERIENCE
+from opendbc.safety import ALTERNATIVE_EXPERIENCE
 from panda.tests.libpanda import libpanda_py
 from panda.tests.safety_replay.helpers import package_can_msg, init_segment
 

--- a/tests/som/on-device.py
+++ b/tests/som/on-device.py
@@ -2,6 +2,7 @@
 import os
 import time
 
+from opendbc.safety import Safety
 from panda import Panda
 
 
@@ -12,7 +13,7 @@ if __name__ == "__main__":
       with Panda(disable_checks=False) as p:
         if not flag_set:
           p.set_heartbeat_disabled()
-          p.set_safety_mode(Panda.SAFETY_ELM327, 30)
+          p.set_safety_mode(Safety.SAFETY_ELM327, 30)
           flag_set = True
 
         # shutdown when told

--- a/tests/som/test_bootkick.py
+++ b/tests/som/test_bootkick.py
@@ -1,6 +1,7 @@
 import time
 import pytest
 
+from opendbc.safety import Safety
 from panda import Panda, PandaJungle
 
 PANDA_SERIAL = "28002d000451323431333839"
@@ -48,7 +49,7 @@ def setup_state(panda, jungle, state):
     jungle.set_panda_individual_power(OBDC_PORT, 1)
     wait_for_boot(panda, jungle)
     set_som_shutdown_flag(panda)
-    panda.set_safety_mode(Panda.SAFETY_SILENT)
+    panda.set_safety_mode(Safety.SAFETY_SILENT)
     panda.send_heartbeat()
     wait_for_som_shutdown(panda, jungle)
   else:
@@ -82,7 +83,7 @@ def wait_for_full_poweroff(jungle, timeout=30):
 
 def check_som_boot_flag(panda):
   h = panda.health()
-  return h['safety_mode'] == Panda.SAFETY_ELM327 and h['safety_param'] == 30
+  return h['safety_mode'] == Safety.SAFETY_ELM327 and h['safety_param'] == 30
 
 def set_som_shutdown_flag(panda):
   panda.set_can_data_speed_kbps(0, 1000)

--- a/tests/spam_can.py
+++ b/tests/spam_can.py
@@ -2,6 +2,7 @@
 import os
 import random
 
+from opendbc.safety import Safety
 from panda import Panda
 
 def get_test_string():
@@ -9,7 +10,7 @@ def get_test_string():
 
 if __name__ == "__main__":
   p = Panda()
-  p.set_safety_mode(Panda.SAFETY_ALLOUTPUT)
+  p.set_safety_mode(Safety.SAFETY_ALLOUTPUT)
 
   print("Spamming all buses...")
   while True:

--- a/tests/standalone_test.py
+++ b/tests/standalone_test.py
@@ -2,6 +2,7 @@
 import struct
 import time
 
+from opendbc.safety import Safety
 from panda import Panda
 
 if __name__ == "__main__":
@@ -15,7 +16,7 @@ if __name__ == "__main__":
   t2 = time.time()
   print("100 requests took %.2f ms" % ((t2 - t1) * 1000))
 
-  p.set_safety_mode(Panda.SAFETY_ALLOUTPUT)
+  p.set_safety_mode(Safety.SAFETY_ALLOUTPUT)
 
   a = 0
   while True:

--- a/tests/usbprotocol/test_comms.py
+++ b/tests/usbprotocol/test_comms.py
@@ -2,7 +2,8 @@
 import random
 import unittest
 
-from panda import Panda, DLC_TO_LEN, USBPACKET_MAX_SIZE, pack_can_buffer, unpack_can_buffer
+from opendbc.safety import Safety
+from panda import DLC_TO_LEN, USBPACKET_MAX_SIZE, pack_can_buffer, unpack_can_buffer
 from panda.tests.libpanda import libpanda_py
 
 lpp = libpanda_py.libpanda
@@ -101,7 +102,7 @@ class TestPandaComms(unittest.TestCase):
 
 
   def test_can_send_usb(self):
-    lpp.set_safety_hooks(Panda.SAFETY_ALLOUTPUT, 0)
+    lpp.set_safety_hooks(Safety.SAFETY_ALLOUTPUT, 0)
 
     for bus in range(3):
       with self.subTest(bus=bus):


### PR DESCRIPTION
## Summary by Sourcery

Sync commaai/panda:master into sunnypilot/panda:master-new. Add support for microphone input, sync SAI clocks, and process mic input in the sound driver. Limit CAN core resets to 10Hz. Correct a typo in a function name. Update LED GPIO pins for Cuatro board v1.1. Remove unused constants and flags. Introduce new safety flags and models.

New Features:
- Add support for microphone input via DFSDM.
- Introduce new safety flag `Safety.SAFETY_HYUNDAI_CANFD` and `HyundaiSafetyFlags`.
- Add safety model `Safety.SAFETY_SUBARU_PREGLOBAL` with reversed driver torque flag.
- Add Toyota safety flags.
- Add Chrysler safety flags.
- Add GM safety flags.
- Add Honda safety flags.
- Add Ford safety flags.
- Add Nissan safety flags.
- Add Tesla safety flags.
- Add Volkswagen safety flags.
- Add Subaru safety flags

Tests:
- Update Hyundai safety tests to use new `HyundaiSafetyFlags`.
- Update tests to use new safety flags and models.
- Update tests to account for changes in CAN message addresses and contents.

Chores:
- Remove unused constants and flags from `panda.py`.
- Update sound driver to sync SAI clocks and process mic input.
- Reduce `SOUND_RX_BUF_SIZE` from 2000 to 1000 and introduce `MIC_RX_BUF_SIZE` of 512.
- Limit the frequency of CAN core resets to 10Hz to avoid blocking operations.
- Correct typo in function name `board_v[1/2]_enable_can_transciever` to `board_v[1/2]_enable_can_transceiver`.
- Update LED GPIO pins for Cuatro board (v1.1).