### PR TITLE
Revert "Log divergent registers once (#2182)"

### DIFF
--- a/board/drivers/registers.h
+++ b/board/drivers/registers.h
@@ -49,10 +49,13 @@ void check_registers(void){
     if((uint32_t) register_map[i].address != 0U){
       ENTER_CRITICAL()
       if((*(register_map[i].address) & register_map[i].check_mask) != (register_map[i].value & register_map[i].check_mask)){
-        if(!register_map[i].logged_fault){
-          print("Register 0x"); puth((uint32_t) register_map[i].address); print(" divergent! Map: 0x"); puth(register_map[i].value); print(" Reg: 0x"); puth(*(register_map[i].address)); print("\n");
-          register_map[i].logged_fault = true;
-        }
+        #ifdef DEBUG_FAULTS
+          print("Register at address 0x"); puth((uint32_t) register_map[i].address); print(" is divergent!");
+          print("   Map: 0x"); puth(register_map[i].value);
+          print("   Register: 0x"); puth(*(register_map[i].address));
+          print("   Mask: 0x"); puth(register_map[i].check_mask);
+          print("\n");
+        #endif
         fault_occurred(FAULT_REGISTER_DIVERGENT);
       }
       EXIT_CRITICAL()

--- a/board/drivers/registers_declarations.h
+++ b/board/drivers/registers_declarations.h
@@ -4,7 +4,6 @@ typedef struct reg {
   volatile uint32_t *address;
   uint32_t value;
   uint32_t check_mask;
-  bool logged_fault;
 } reg;
 
 // 10 bit hash with 23 as a prime


### PR DESCRIPTION
This reverts commit a2d8ad9486fb429a2ce27abb5879b9ca8f26dfa4.

This was causing the internal panda to get stuck during flashing. Reverting for now until upstream has a fix for this.

## Summary by Sourcery

Revert a previous change that logged divergent registers, which was causing issues during device flashing

Bug Fixes:
- Remove the repeated logging of divergent registers to prevent device flashing problems

Enhancements:
- Modify register checking to only print debug information when DEBUG_FAULTS is defined