### PR TITLE
Sync: `commaai/panda:master` into `sunnypilot/panda:master-new`

### DIFF
--- a/board/drivers/clock_source.h
+++ b/board/drivers/clock_source.h
@@ -1,7 +1,12 @@
 #include "clock_source_declarations.h"
 
-void clock_source_set_period(uint8_t period) {
-  register_set(&(TIM1->ARR), ((period*10U) - 1U), 0xFFFFU);
+void clock_source_set_timer_params(uint16_t param1, uint16_t param2) {
+  // Pulse length of each channel
+  register_set(&(TIM1->CCR1), (((param1 & 0xFF00U) >> 8U)*10U), 0xFFFFU);
+  register_set(&(TIM1->CCR2), ((param1 & 0x00FFU)*10U), 0xFFFFU);
+  register_set(&(TIM1->CCR3), (((param2 & 0xFF00U) >> 8U)*10U), 0xFFFFU);
+  // Timer period
+  register_set(&(TIM1->ARR),  (((param2 & 0x00FFU)*10U) - 1U), 0xFFFFU);
 }
 
 void clock_source_init(bool enable_channel1) {

--- a/board/drivers/clock_source_declarations.h
+++ b/board/drivers/clock_source_declarations.h
@@ -3,5 +3,5 @@
 #define CLOCK_SOURCE_PERIOD_MS           50U
 #define CLOCK_SOURCE_PULSE_LEN_MS        2U
 
-void clock_source_set_period(uint8_t period);
+void clock_source_set_timer_params(uint16_t param1, uint16_t param2);
 void clock_source_init(bool enable_channel1);

--- a/board/main_comms.h
+++ b/board/main_comms.h
@@ -311,9 +311,9 @@ int comms_control_handler(ControlPacket_t *req, uint8_t *resp) {
       can_loopback = req->param1 > 0U;
       can_init_all();
       break;
-    // **** 0xe6: set custom clock source period
+    // **** 0xe6: set custom clock source period and pulse length
     case 0xe6:
-      clock_source_set_period(req->param1);
+      clock_source_set_timer_params(req->param1, req->param2);
       break;
     // **** 0xe7: set power save state
     case 0xe7:

--- a/python/__init__.py
+++ b/python/__init__.py
@@ -860,8 +860,12 @@ class Panda:
   def set_green_led(self, enabled):
     self._handle.controlWrite(Panda.REQUEST_OUT, 0xf7, int(enabled), 0, b'')
 
-  def set_clock_source_period(self, period):
-    self._handle.controlWrite(Panda.REQUEST_OUT, 0xe6, period, 0, b'')
+  # arr: timer period
+  # ccrN: channel N pulse length
+  def set_clock_source_timer_params(self, arr, ccr1, ccr2, ccr3):
+    param1 = ((ccr1 & 0xFF) << 8) | (ccr2 & 0xFF)
+    param2 = ((ccr3 & 0xFF) << 8) | (arr & 0xFF)
+    self._handle.controlWrite(Panda.REQUEST_OUT, 0xe6, param1, param2, b'')
 
   def force_relay_drive(self, intercept_relay_drive, ignition_relay_drive):
     self._handle.controlWrite(Panda.REQUEST_OUT, 0xc5, (int(intercept_relay_drive) | int(ignition_relay_drive) << 1), 0, b'')


### PR DESCRIPTION
## Summary by Sourcery

Extend the clock source interface to support per-channel pulse lengths and a custom timer period, and propagate these changes through the firmware comms handler and Python API.

Enhancements:
- Replace single-period clock configuration with a two-parameter timer API that sets individual channel pulse lengths and the timer period
- Update firmware comms handler to forward both parameters for custom clock source configuration
- Revise Python interface to encode and send the new timer parameters instead of a single period
- Adjust clock source driver declarations to reflect the new timer parameter function signature