### PR TITLE
Sync 20250710

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -8,17 +8,12 @@ AddOption('--ubsan',
           action='store_true',
           help='turn on UBSan')
 
-AddOption('--compile_db',
-          action='store_true',
-          help='build clang compilation database')
-
 env = Environment(
   COMPILATIONDB_USE_ABSPATH=True,
   tools=["default", "compilation_db"],
 )
 
-if GetOption('compile_db'):
-  env.CompilationDatabase("compile_commands.json")
+env.CompilationDatabase("compile_commands.json")
 
 # panda fw & test files
 SConscript('SConscript')


### PR DESCRIPTION
> [!NOTE]
> Sister PRS:
> * https://github.com/sunnypilot/sunnypilot/pull/1034
> * https://github.com/sunnypilot/opendbc/pull/194

## Summary by Sourcery

Enhancements:
- Remove the --compile_db option and unconditionally generate the clang compilation database

## Summary by Sourcery

Enhancements:
- Remove the --compile_db option and always generate the clang compilation database in SConstruct