### PR TITLE
Sync: `commaai/panda:master` into `sunnypilot/panda:master`

### DIFF
--- a/.github/workflows/update-cppcheck.yml
+++ b/.github/workflows/update-cppcheck.yml
@@ -1,0 +1,37 @@
+name: Update cppcheck
+
+on:
+  #push:
+  schedule:
+    - cron: "0 14 * * 1" # every Monday at 2am UTC (6am PST)
+  workflow_dispatch:
+
+jobs:
+  update-cppcheck:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Get latest cppcheck version
+        id: version
+        run: |
+          LATEST=$(curl -fsSL https://api.github.com/repos/danmar/cppcheck/releases/latest | jq -r .tag_name)
+          echo "vers=$LATEST" >> "$GITHUB_OUTPUT"
+      - name: Update VERS in install.sh
+        run: |
+          sed -i "s/^VERS=\".*\"/VERS=\"${{ steps.version.outputs.vers }}\"/" tests/misra/install.sh
+          grep VERS tests/misra/install.sh
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@9153d834b60caba6d51c9b9510b087acf9f33f83
+        with:
+          author: Vehicle Researcher <user@comma.ai>
+          token: ${{ secrets.ACTIONS_CREATE_PR_PAT }}
+          commit-message: "[bot] Update cppcheck to ${{ steps.version.outputs.vers }}"
+          title: "[bot] Update cppcheck to ${{ steps.version.outputs.vers }}"
+          body: "See all cppcheck releases: https://github.com/danmar/cppcheck/releases"
+          branch: "update-cppcheck"
+          base: "master"
+          delete-branch: true
+          labels: bot

--- a/python/__init__.py
+++ b/python/__init__.py
@@ -114,6 +114,8 @@ class Panda:
 
   # from https://github.com/commaai/openpilot/blob/103b4df18cbc38f4129555ab8b15824d1a672bdf/cereal/log.capnp#L648
   HW_TYPE_UNKNOWN = b'\x00'
+  HW_TYPE_WHITE = b'\x01'
+  HW_TYPE_BLACK = b'\x03'
   HW_TYPE_DOS = b'\x06'
   HW_TYPE_RED_PANDA = b'\x07'
   HW_TYPE_TRES = b'\x09'
@@ -125,10 +127,11 @@ class Panda:
   HEALTH_STRUCT = struct.Struct("<IIIIIIIIBBBBBHBBBHfBBHBHHB")
   CAN_HEALTH_STRUCT = struct.Struct("<BIBBBBBBBBIIIIIIIHHBBBIIII")
 
-  F4_DEVICES = [HW_TYPE_DOS, ]
+  F4_DEVICES = [HW_TYPE_WHITE, HW_TYPE_BLACK, HW_TYPE_DOS, ]
   H7_DEVICES = [HW_TYPE_RED_PANDA, HW_TYPE_TRES, HW_TYPE_CUATRO]
 
   INTERNAL_DEVICES = (HW_TYPE_DOS, HW_TYPE_TRES, HW_TYPE_CUATRO)
+  DEPRECATED_DEVICES = (HW_TYPE_WHITE, HW_TYPE_BLACK)
 
   MAX_FAN_RPMs = {
     HW_TYPE_DOS: 6500,
@@ -230,6 +233,10 @@ class Panda:
     self._mcu_type = self.get_mcu_type()
     self.health_version, self.can_version, self.can_health_version = self.get_packets_versions()
     logger.debug("connected")
+
+    hw_type = self.get_type()
+    if hw_type in Panda.DEPRECATED_DEVICES:
+      print("WARNING: Using deprecated HW")
 
     # disable openpilot's heartbeat checks
     if self._disable_checks:
@@ -345,9 +352,10 @@ class Panda:
     return isinstance(self._handle, PandaUsbHandle)
 
   @classmethod
-  def list(cls):
+  def list(cls, usb_only: bool = False):
     ret = cls.usb_list()
-    ret += cls.spi_list()
+    if not usb_only:
+      ret += cls.spi_list()
     return list(set(ret))
 
   @classmethod
@@ -459,6 +467,10 @@ class Panda:
     if self.up_to_date(fn=fn):
       logger.info("flash: already up to date")
       return
+
+    hw_type = self.get_type()
+    if hw_type in Panda.DEPRECATED_DEVICES:
+      raise RuntimeError(f"HW type {hw_type.hex()} is deprecated and can no longer be flashed.")
 
     if not fn:
       fn = os.path.join(FW_PATH, self._mcu_type.config.app_fn)


### PR DESCRIPTION
## Summary by Sourcery

Merge commaai/panda upstream changes into sunnypilot/panda, deprecate White and Black hardware, enhance device listing, and add a CI workflow for automatic Cppcheck updates.

Enhancements:
- Add constants for HW_TYPE_WHITE and HW_TYPE_BLACK and include them in F4_DEVICES
- Mark White and Black devices as deprecated, print a warning on connection, and block firmware flashing for them
- Extend Panda.list() with a usb_only flag to optionally exclude SPI devices

CI:
- Introduce a GitHub Actions workflow to schedule weekly updates of the Cppcheck version