### PR TITLE
UART: lower FIFO size

### DIFF
--- a/board/drivers/uart_declarations.h
+++ b/board/drivers/uart_declarations.h
@@ -1,7 +1,11 @@
 #pragma once
 
 // ***************************** Definitions *****************************
+#ifdef STM32H7
+#define FIFO_SIZE_INT 0x400U
+#else
 #define FIFO_SIZE_INT 0x200U
+#endif
 
 typedef struct uart_ring {
   volatile uint16_t w_ptr_tx;


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Lower the FIFO_SIZE_INT definition from 0x400U to 0x200U in uart_declarations.h