### PR TITLE
ci: update for `master-tici`

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -3,11 +3,11 @@ name: tests
 on:
   push:
     branches:
-      - master
+      - master-tici
   pull_request:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref != 'refs/heads/master' && github.ref || github.run_id }}-${{ github.event_name }}
+  group: ${{ github.workflow }}-${{ github.ref != 'refs/heads/master-tici' && github.ref || github.run_id }}-${{ github.event_name }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/update-cppcheck.yml
+++ b/.github/workflows/update-cppcheck.yml
@@ -32,6 +32,6 @@ jobs:
           title: "[bot] Update cppcheck to ${{ steps.version.outputs.vers }}"
           body: "See all cppcheck releases: https://github.com/danmar/cppcheck/releases"
           branch: "update-cppcheck"
-          base: "master"
+          base: "master-tici"
           delete-branch: true
           labels: bot


### PR DESCRIPTION
## Summary by Sourcery

Update CI workflows to use 'master-tici' as the default branch instead of 'master'

CI:
- Switch test workflow to trigger on 'master-tici' and adjust its concurrency group check
- Set the base branch for update-cppcheck workflow to 'master-tici' instead of 'master'